### PR TITLE
feat(parser): allow custom decorator name

### DIFF
--- a/src/codegen/cli.ts
+++ b/src/codegen/cli.ts
@@ -11,13 +11,14 @@ Usage (C#/Unity)
     schema-codegen src/Schema.ts --output client-side/ --csharp --namespace MyGame.Schema
 
 Valid options:
-    --output: fhe output directory for generated client-side schema files
+    --output: the output directory for generated client-side schema files
     --csharp: generate files for C#/Unity
     --cpp: generate files for C++
     --hx: generate files for Haxe
 
 Optional:
-    --namespace: generate namespace on output code`);
+    --namespace: generate namespace on output code
+    --decorator: custom name for @type decorator to scan for`);
     process.exit();
 }
 
@@ -37,6 +38,11 @@ if (args.csharp) {
     generatorId = 'cpp';
 }
 
+let decoratorName = "type";
+if (args.decorator) {
+    decoratorName = args.decorator;
+}
+
 if (!args.output || !fs.existsSync(args.output)) {
     console.error("You must provide a valid (and existing) --output directory.");
     displayHelp();
@@ -50,7 +56,7 @@ try {
     displayHelp();
 }
 
-const classes = parseFiles(args._);
+const classes = parseFiles(args._, decoratorName);
 const files = generator(classes, args);
 
 files.forEach((file: File) => {


### PR DESCRIPTION
This commit will allow users to override the hardcoded decorator name `@type` for replicated variables in Schema classes by supplying the CLI with the respective decorator command line argument.

In my personal project I have an alias for the `@type` decorator called `@Replicated` which is not picked up by the code generator. This pull request should enables the optional feature to define the decorator name to search for.