### PR TITLE
ArraySchema ordering fixes colyseus.js#53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+lib
+
 # Mac
 .DS_Store
 .vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,444 @@
+{
+  "name": "@colyseus/schema",
+  "version": "0.4.41",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
+      "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",
+      "integrity": "sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "flatbuffers": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.11.0.tgz",
+      "integrity": "sha512-0PqFKtXI4MjxomI7jO4g5XfLPm/15g2R+5WGCHBGYGh0ihQiypnHlJ6bMmkkrAe0GzZ4d7PDAfCONKIPUxNF+A==",
+      "dev": true
+    },
+    "fossil-delta": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fossil-delta/-/fossil-delta-1.0.2.tgz",
+      "integrity": "sha512-fkgQUnBaJjhDq0DN1ajBlWWRH99NQgwVoReMEr0oXLqYXAx8X9mD5gGaoTYDdVVbLJYsMNrnkJ028Ld0UgWrGA==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lolex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
+      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw==",
+      "dev": true
+    },
+    "nise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "notepack.io": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
+      "integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
+    },
+    "sinon": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
+    }
+  }
+}

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -491,9 +491,13 @@ export abstract class Schema {
                 // total of items in the array
                 encode.number(bytes, value.length);
 
-                const arrayChanges = ((encodeAll || client)
-                    ? value.$changes.allChanges
-                    : value.$changes.changes).filter(index => this[`_${field}`][index] !== undefined);
+                const arrayChanges = (
+                    (encodeAll || client)
+                        ? value.$changes.allChanges
+                        : value.$changes.changes
+                    )
+                    .filter(index => this[`_${field}`][index] !== undefined)
+                    .sort((a, b) => a - b);
 
                 // ensure number of changes doesn't exceed array length
                 const numChanges = arrayChanges.length;

--- a/src/types/ArraySchema.ts
+++ b/src/types/ArraySchema.ts
@@ -63,9 +63,18 @@ export class ArraySchema<T=any> extends Array<T> {
 
     splice(start: number, deleteCount?: number, ...insert: T[]) {
         const removedItems = Array.prototype.splice.apply(this, arguments);
+        const movedItems = this.filter((item, idx) => {
+            return idx >= start + deleteCount - 1;
+        });
 
         removedItems.map(removedItem => {
+            (removedItem as any).$changes.parent.deleteIndex(removedItem);
+            (removedItem as any).$changes.parent.deleteIndexChange(removedItem);
             delete (removedItem as any).$changes.parent;
+        });
+
+        movedItems.forEach(movedItem => {
+            (movedItem as any).$changes.parentField--;
         });
 
         return removedItems;

--- a/test/ArraySchemaTest.ts
+++ b/test/ArraySchemaTest.ts
@@ -3,6 +3,7 @@ import * as assert from "assert";
 
 import { State, Player } from "./Schema";
 import { ArraySchema, Schema, type } from "../src";
+import { logChangeTree } from "./helpers/logging";
 
 describe("ArraySchema", () => {
 
@@ -55,7 +56,200 @@ describe("ArraySchema", () => {
         }
     });
 
-    xit("should allow to transfer object between ArraySchema", () => {
+    it("updates all items `idx` props after removing middle item", () => {
+        /**
+         * In this scenario, after splicing middle item, I'm updating
+         * each item's `idx` property, to reflect its current "index".
+         * After remiving "Item 3", items 4 and 5 would get their
+         * `idx` updated. Rest of properties should remain unchanged.
+         */
+        const stringifyItem = i => `[${i.idx}] ${i.name} (${i.id})`;
+
+        class Item extends Schema {
+            @type("uint8") id: number;
+            @type("uint8") idx: number;
+            @type("string") name: string;
+            constructor(name, idx) {
+                super();
+                this.idx = idx;
+                this.name = name;
+                this.id = Math.round(Math.random() * 250);
+            }
+        }
+        class Player extends Schema {
+            @type([Item]) items = new ArraySchema<Item>();
+        }
+        class State extends Schema {
+            @type(Player) player1 = new Player();
+        }
+
+        const state = new State();
+        const decodedState = new State();
+        decodedState.decode(state.encodeAll());
+
+        state.player1.items.push(new Item("Item 0", 0));
+        state.player1.items.push(new Item("Item 1", 1));
+        state.player1.items.push(new Item("Item 2", 2));
+        state.player1.items.push(new Item("Item 3", 3));
+        state.player1.items.push(new Item("Item 4", 4));
+        decodedState.decode(state.encodeAll());
+        assert.equal(decodedState.player1.items.length, 5);
+
+        // Remove one item
+        state.player1.items.splice(2, 1);
+        decodedState.decode(state.encode());
+        
+        assert.equal(decodedState.player1.items.length, 4);
+        
+        // Update `idx` of each item
+        state.player1.items
+            .forEach((item, idx) => item.idx = idx);
+        // After below encoding, Item 4 is not marked as `changed`
+        decodedState.decode(state.encode());
+
+        const resultPreEncoding = state.player1.items
+            .map(stringifyItem).join(',');
+        const resultPostEncoding = decodedState.player1.items
+            .map(stringifyItem).join(',');
+
+        // Ensure all data is perserved and `idx` is updated for each item
+        assert.equal(
+            resultPostEncoding,
+            resultPreEncoding,
+            `There's a difference between state and decoded state on some items`
+        );
+    });
+
+    it("updates an item after removing another", () => {
+        class Item extends Schema {
+            @type("string") name: string;
+            constructor(name) {
+                super();
+                this.name = name;
+            }
+        }
+        class Player extends Schema {
+            @type([Item]) items = new ArraySchema<Item>();
+        }
+        class State extends Schema {
+            @type(Player) player = new Player();
+        }
+
+        const state = new State();
+        const decodedState = new State();
+        decodedState.decode(state.encodeAll());
+
+        state.player.items.push(new Item("Item 1"));
+        state.player.items.push(new Item("Item 2"));
+        state.player.items.push(new Item("Item 3"));
+        state.player.items.push(new Item("Item 4"));
+        state.player.items.push(new Item("Item 5"));
+        decodedState.decode(state.encodeAll());
+
+        // Remove Item 2
+        const [ removedItem ] = state.player.items.splice(1, 1);
+        assert.equal(removedItem.name, "Item 2");
+        decodedState.decode(state.encode());
+        
+        // Update `name` of remaining item
+        const preEncoding = state.player.items[1].name = "Item 3 changed!";
+        decodedState.decode(state.encode());
+
+        assert.equal(
+            decodedState.player.items[1].name,
+            preEncoding,
+            `new name of Item 3 was not reflected during recent encoding/decoding.`
+        );
+    });
+
+    it("tests splicing one item out and adding it back again", () => {
+        /**
+         * Scenario: splice out the middle item
+         * and push it back at the last index.
+         */
+        class Item extends Schema {
+            @type("string") name: string;
+            @type("uint8") x: number;
+            constructor(name, x) {
+                super();
+                this.name = name;
+                this.x = x;
+            }
+        }
+        class State extends Schema {
+            @type([Item]) items = new ArraySchema();
+        }
+        // Just updates x position on item
+        const updateItem = (item, idx) => item.x = idx * 10;
+
+        const state = new State();
+        const decodedState = new State();
+
+        state.items = new ArraySchema<Item>();
+        state.items.push(new Item("Item One", 1 * 10));
+        state.items.push(new Item("Item Two", 2 * 10));
+        state.items.push(new Item("Item Three", 3 * 10));
+        state.items.push(new Item("Item Four", 4 * 10));
+        state.items.push(new Item("Item Five", 5 * 10));
+        decodedState.decode(state.encodeAll());
+
+        /**
+         * Splice one item out (and remember its reference)
+         */
+        const [itemThree] = state.items.splice(2, 1);
+        state.items.forEach(updateItem);
+        decodedState.decode(state.encodeAll());
+        
+        assert.strictEqual(state.items[0].name, 'Item One');
+        assert.strictEqual(state.items[1].name, 'Item Two');
+        assert.strictEqual(state.items[2].name, 'Item Four');
+        assert.strictEqual(state.items[3].name, 'Item Five');
+
+        // ItemThree is forgotten
+        assert.strictEqual((state.items as any).$changes.indexMap.get(itemThree), undefined);
+        // The rest of the items stay in correct indexes
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[0]), 0);
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[1]), 1);
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[2]), 2);
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[3]), 3);
+        assert.strictEqual(
+            (state.items as any).$changes.indexMap.size, 4,
+            `$changes.indexMap should forget about previously removed item, but it still contains: ${logChangeTree((state.items as any).$changes)}`
+        );
+
+        // console.log(
+        //     `After splicing one item out`,
+        //     logChangeTree((state.items as any).$changes)
+        // );
+
+        assert.deepEqual(state.items, decodedState.items);
+
+        /**
+         * Add the item back in
+         */
+        state.items.push(itemThree);
+        state.items.forEach(updateItem);
+        decodedState.decode(state.encodeAll());
+
+        // console.log(
+        //     `After pushing that item back inside`,
+        //     logChangeTree((state.items as any).$changes)
+        // );
+
+        assert.strictEqual(state.items[0].name, 'Item One');
+        assert.strictEqual(state.items[1].name, 'Item Two');
+        assert.strictEqual(state.items[2].name, 'Item Four');
+        assert.strictEqual(state.items[3].name, 'Item Five');
+        assert.strictEqual(state.items[4].name, 'Item Three');
+
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[0]), 0);
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[1]), 1);
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[2]), 2);
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[3]), 3);
+        assert.strictEqual((state.items as any).$changes.indexMap.get(state.items[4]), 4);
+    });
+
+    it("should allow to transfer object between ArraySchema", () => {
         class Item extends Schema {
             @type("uint8") id: number;
             @type("string") name: string;

--- a/test/helpers/logging.ts
+++ b/test/helpers/logging.ts
@@ -1,0 +1,19 @@
+import { ChangeTree } from "../../src/ChangeTree";
+
+export const logChangeTree = (tree: ChangeTree) => {
+    if (!tree) return '{empty}'
+    const logMap = (map: Map<any, string | number | symbol>) => {
+        return [...map.entries()]
+            .map(([key, value]) => `Item"${key.name}".${key.x} => ${String(value)}`)
+    }
+    return `
+{
+  changes:  [${tree.changes}]
+  indexMap: {
+    ${logMap(tree.indexMap).join(`\n    `)}
+  }
+  indexChange: {
+    ${logMap(tree.indexChange).join(`\n    `)}
+  }
+}\n`
+}

--- a/test/helpers/logging.ts
+++ b/test/helpers/logging.ts
@@ -3,8 +3,11 @@ import { ChangeTree } from "../../src/ChangeTree";
 export const logChangeTree = (tree: ChangeTree) => {
     if (!tree) return '{empty}'
     const logMap = (map: Map<any, string | number | symbol>) => {
-        return [...map.entries()]
-            .map(([key, value]) => `Item"${key.name}".${key.x} => ${String(value)}`)
+        let result = []
+        map.forEach(
+            (value, key) => result.push(`Item"${key.name}".${key.x} => ${String(value)}`)
+        )
+        return result
     }
     return `
 {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../tsconfig.json",
+    "include": ["./"]
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,4 @@
 {
     "extends": "../tsconfig.json",
-    "compilerOptions": {
-        "downlevelIteration": true,
-    },
     "include": ["./"]
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,4 +1,7 @@
 {
     "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "downlevelIteration": true,
+    },
     "include": ["./"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
         "lib": ["es6"],
         "target": "es5",
         "declaration": true,
-        "downlevelIteration": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
         "sourceMap": false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "lib": ["es6"],
         "target": "es5",
         "declaration": true,
+        "downlevelIteration": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
         "sourceMap": false


### PR DESCRIPTION
Fixes and tests for colyseus/colyseus.js#53

### Schema.ts, order changes by item's indexes

This prevents an item from being incorrectly marked with `isNew = true` in one of the `decode()` loops. In the case I had (screen below) index drops from 7 to 0 in the next item. This in turn creates current item anew with `createTypeInstance` - all prop values are cleared. Lastly, It applies values of only the props which happen to also come with this change.

 <img src="https://user-images.githubusercontent.com/625693/61896985-66c77600-af16-11e9-8a08-9e36b43cc5f3.png" width="300" alt="" />

### ArraySchema.ts, make parent completely forget about spliced out item.

During `array.splice(x,y)` removed items are still remembered in the ChangeTree. In my case, this appeared with the following bug:

<img src="https://user-images.githubusercontent.com/625693/61898596-f4589500-af19-11e9-9c11-f156ae319d40.gif" width="300" alt="" />

That empty space is actually a "clone" of that same card, React complains about duplicate `key` identifier. Below you can see 8 of spades ("S8") in two places. 

![image](https://user-images.githubusercontent.com/625693/61898666-2538ca00-af1a-11e9-95a1-579c99810f43.png)


### Housekeeping changes
- add /lib/ to gitignore
- it helps to keep package-lock.json in the repo ;)
- tsconfig in /test/, so IDE stops complaining about decorators (VSCode here).