### PR TITLE
add defineTypes() to simplify for plain js users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/schema",
-  "version": "0.4.46",
+  "version": "0.4.47",
   "description": "Schema-based binary serializer / de-serializer.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -1,7 +1,4 @@
 import { ChangeTree } from './ChangeTree';
-
-import { ArraySchema } from './types/ArraySchema';
-import { MapSchema } from './types/MapSchema';
 import { Schema } from './Schema';
 
 /**
@@ -237,4 +234,11 @@ export function filter(cb: FilterCallback): PropertyDecorator  {
 
         constructor._filters[field] = cb;
     }
+}
+
+export function defineTypes(target: typeof Schema, fields: {[property: string]: DefinitionType}) {
+    for (let field in fields) {
+        type(fields[field])(target.prototype, field);
+    }
+    return target;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
     // Annotations
     type,
     filter,
+    defineTypes,
 
     // Types
     Context,

--- a/test/DefinitionTest.ts
+++ b/test/DefinitionTest.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 
-import { Schema, type, Reflection, MapSchema } from "../src";
+import { Schema, type, MapSchema } from "../src";
+import { defineTypes } from "../src/annotations";
 
 describe("Definition", () => {
 
@@ -35,4 +36,17 @@ describe("Definition", () => {
         assert.deepEqual(Object.keys(obj), []);
     });
 
+    describe("defineTypes", () => {
+        it("should be equivalent", () => {
+            class MyExistingStructure extends Schema {}
+            defineTypes(MyExistingStructure, { name: "string" });
+
+            const state = new MyExistingStructure();
+            (state as any).name = "hello world!";
+
+            const decodedState = new MyExistingStructure();
+            decodedState.decode(state.encode());
+            assert.equal((decodedState as any).name, "hello world!");
+        });
+    });
 });


### PR DESCRIPTION
Here's a comparison on how the Schema definition would look like in plain JavaScript. I believe this alternative is more intuitive than it used to be. 

It would be nice to incorporate #9 on this as well. Do you have any ideas @amir-arad?

**BEFORE**

```javascript
class World extends Schema {
}
type("number")(World.prototype, "width");
type("number")(World.prototype, "height");
type("number")(World.prototype, "items");

class MyState extends Schema {
    constructor () {
        super();

        this.world = new World();
    }
}
type(World)(MyState.prototype, "world");

```

**AFTER**

```javascript
class World extends Schema {
}
defineTypes(World, {
    width: "number",
    height: "number",
    items: "number"
});

class MyState extends Schema {
    constructor () {
        super();

        this.world = new World();
    }
}
defineTypes(MyState, {
    world: World
});
```