### PR TITLE
Fix ArraySchema's splice not working for primitive values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/schema",
-  "version": "0.4.42",
+  "version": "0.4.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/types/ArraySchema.ts
+++ b/src/types/ArraySchema.ts
@@ -83,13 +83,19 @@ export class ArraySchema<T=any> extends Array<T> {
         });
 
         removedItems.map(removedItem => {
-            (removedItem as any).$changes.parent.deleteIndex(removedItem);
-            (removedItem as any).$changes.parent.deleteIndexChange(removedItem);
-            delete (removedItem as any).$changes.parent;
+            // If the removed item is a schema we need to update it.
+            if (removedItem && (removedItem as any).$changes) {
+                (removedItem as any).$changes.parent.deleteIndex(removedItem);
+                (removedItem as any).$changes.parent.deleteIndexChange(removedItem);
+                delete (removedItem as any).$changes.parent;
+            }
         });
 
         movedItems.forEach(movedItem => {
-            (movedItem as any).$changes.parentField--;
+            // If the moved item is a schema we need to update it.
+            if (movedItem && (movedItem as any).$changes) {
+                (movedItem as any).$changes.parentField--;
+            }
         });
 
         return removedItems;

--- a/test/ArraySchemaTest.ts
+++ b/test/ArraySchemaTest.ts
@@ -339,4 +339,39 @@ describe("ArraySchema", () => {
         console.log(decodedState.player2.items.map(item => item.name));
     });
 
+    it("test splicing an ArraySchema of primitive values", () => {
+        class Player extends Schema {
+            @type(["string"]) itemIds = new ArraySchema<string>();
+        }
+        class State extends Schema {
+            @type(Player) player = new Player();
+        }
+
+        const state = new State();
+        const decodedState = new State();
+        decodedState.decode(state.encodeAll());
+
+        state.player.itemIds.push("Item 1");
+        state.player.itemIds.push("Item 2");
+        state.player.itemIds.push("Item 3");
+        state.player.itemIds.push("Item 4");
+        state.player.itemIds.push("Item 5");
+        decodedState.decode(state.encodeAll());
+
+        // Remove Item 2
+        const [ removedItem ] = state.player.itemIds.splice(1, 1);
+        assert.strictEqual(removedItem, "Item 2");
+        decodedState.decode(state.encode());
+
+        // Update remaining item
+        const preEncoding = state.player.itemIds[1] = "Item 3 changed!";
+        decodedState.decode(state.encode());
+
+        assert.strictEqual(
+            decodedState.player.itemIds[1],
+            preEncoding,
+            `new name of Item 3 was not reflected during recent encoding/decoding.`
+        );
+    });
+
 });


### PR DESCRIPTION
The current `splice` implementation assumes that all moved/removed values have a `$changes` property, which isn't true for primitive types.