### PR TITLE
Mark items for index change only ONCE.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/schema",
-  "version": "0.5.2",
+  "version": "0.5.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ChangeTree.ts
+++ b/src/ChangeTree.ts
@@ -81,9 +81,9 @@ export class ChangeTree {
         return this.deletedKeys[key] !== undefined;
     }
 
-    mapIndexChange(instance: any, key: FieldKey) {
-        if (typeof instance === "object") {
-            this.indexChange.set(instance, key);
+    mapIndexChange(instance: any, previousKey: FieldKey) {
+        if (typeof instance === "object" && !this.indexChange.has(instance)) {
+            this.indexChange.set(instance, previousKey);
         }
     }
 

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -454,13 +454,13 @@ export abstract class Schema {
 
                 encode.number(bytes, fieldIndex);
 
-                // total of items in the array
+                // total number of items in the array
                 encode.number(bytes, value.length);
 
                 const arrayChanges = Array.from(
-                        (encodeAll || client)
-                            ? $changes.allChanges
-                            : $changes.changes
+                    (encodeAll || client)
+                        ? $changes.allChanges
+                        : $changes.changes
                     )
                     .filter(index => this[_field][index] !== undefined)
                     .sort((a: number, b: number) => a - b);
@@ -504,7 +504,7 @@ export abstract class Schema {
 
                         (item as Schema).encode(root, encodeAll, client, bytes);
 
-                    } else if (item !== undefined) {
+                    } else if (item !== undefined) { // is array of primitives
                         encode.number(bytes, index);
                         encodePrimitiveType(type[0], bytes, item, this, field);
                     }

--- a/src/types/ArraySchema.ts
+++ b/src/types/ArraySchema.ts
@@ -107,19 +107,24 @@ export class ArraySchema<T=any> extends Array<T> {
         });
 
         removedItems.map(removedItem => {
+            const $changes = removedItem && (removedItem as any).$changes;
             // If the removed item is a schema we need to update it.
-            if (removedItem && (removedItem as any).$changes) {
-                (removedItem as any).$changes.parent.deleteIndex(removedItem);
-                (removedItem as any).$changes.parent.deleteIndexChange(removedItem);
-                delete (removedItem as any).$changes.parent;
+            if ($changes) {
+                $changes.parent.deleteIndex(removedItem);
+                delete $changes.parent;
             }
         });
 
         movedItems.forEach(movedItem => {
             // If the moved item is a schema we need to update it.
-            if (movedItem && (movedItem as any).$changes) {
-                (movedItem as any).$changes.parentField--;
+            const $changes = movedItem && (movedItem as any).$changes;
+
+            if ($changes) {
+                // Update current index in parent, so subsequent changes in
+                // this item's properties are correctly reflected.
+                $changes.parentField--;
             }
+
         });
 
         return removedItems;


### PR DESCRIPTION
The actual fix is only in `src/ChangeTree.ts` file, the rest were only some code improvements or comments (so it's easier to navigate :) )

The fix: Added new check `&& !this.indexChange.has(instance)` to see if the item was already added here.
I also changed the second argument, so it's more clear what it is. `indexChange` is about marking what indexes the items had before changes:

```typescript
mapIndexChange(instance: any, previousKey: FieldKey) {
    if (typeof instance === "object" && !this.indexChange.has(instance)) {
        this.indexChange.set(instance, previousKey);
    }
}
```
 
### Example:

For two `splice()` executions, one item is caught in "set" proxy handler, to be moved in array to its new index. Below snippet then ads new value in "indexChange" for our moved item.

```typescript
// annotations.ts:126
if (previousIndex !== undefined) {
     obj.$changes.mapIndexChange(setValue, previousIndex);
}
```

And here's how the story goes:
```
[0:A, 1:B, 2:C] // my items array, "index:NAME" format
=> splice(0,1)
--> set(items, "1", itemC)
---> mapIndexChange(itemC, 2)
[0:B, 1:C] // here, C would have its "indexChange" value set to "2", correctly.

=> splice(0,1) again
--> set(items, "0", itemC)
---> mapIndexChange(itemC, 1)
// ^ 🐛 "previousIndex" is provided, but the value is what it was before the first splice.
[0:C] // here, C would have "indexChange" set to "1"
```

Item C was moved from `2` down to `0`, but index `1` will be sent to client instead.

The issue I had:
![selection-issues](https://user-images.githubusercontent.com/625693/70450884-c62cb980-1aa4-11ea-8f09-9425d9c35c39.gif)

After solving it:
![selection-solved](https://user-images.githubusercontent.com/625693/70450921-d3e23f00-1aa4-11ea-8697-c44311e85a7e.gif)
