### PR TITLE
schema-codegen: generate classes for interfaces on C#/Unity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/schema",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "Schema-based binary serializer / de-serializer.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/codegen/api.ts
+++ b/src/codegen/api.ts
@@ -31,12 +31,12 @@ export function generate(targetId: string, options: GenerateOptions) {
      */
     if (!options.decorator) { options.decorator = "type"; }
 
-    const classes = parseFiles(options.files, options.decorator);
+    const structures = parseFiles(options.files, options.decorator);
 
     // Post-process classes before generating
-    classes.forEach(klass => klass.postProcessing());
+    structures.classes.forEach(klass => klass.postProcessing());
 
-    const files = generator(classes, options);
+    const files = generator(structures, options);
 
     files.forEach((file: File) => {
         const outputPath = path.resolve(options.output, file.name);

--- a/src/codegen/languages/cpp.ts
+++ b/src/codegen/languages/cpp.ts
@@ -1,4 +1,4 @@
-import { Class, Property, File, getCommentHeader, getInheritanceTree } from "../types";
+import { Class, Property, File, getCommentHeader, getInheritanceTree, Context } from "../types";
 import { GenerateOptions } from "../api";
 
 const typeMaps = {
@@ -43,10 +43,10 @@ const capitalize = (s) => {
 }
 const distinct = (value, index, self) => self.indexOf(value) === index;
 
-export function generate (classes: Class[], options: GenerateOptions): File[] {
-    return classes.map(klass => ({
+export function generate (context: Context, options: GenerateOptions): File[] {
+    return context.classes.map(klass => ({
         name: klass.name + ".hpp",
-        content: generateClass(klass, options.namespace, classes)
+        content: generateClass(klass, options.namespace, context.classes)
     }));
 }
 

--- a/src/codegen/languages/haxe.ts
+++ b/src/codegen/languages/haxe.ts
@@ -1,4 +1,4 @@
-import { Class, Property, File, getCommentHeader } from "../types";
+import { Class, Property, File, getCommentHeader, Context } from "../types";
 import { GenerateOptions } from "../api";
 
 const typeMaps = {
@@ -33,10 +33,10 @@ const typeInitializer = {
     "float64": "0",
 }
 
-export function generate (classes: Class[], options: GenerateOptions): File[] {
-    return classes.map(klass => ({
+export function generate (context: Context, options: GenerateOptions): File[] {
+    return context.classes.map(klass => ({
         name: klass.name + ".hx",
-        content: generateClass(klass, options.namespace, classes)
+        content: generateClass(klass, options.namespace, context.classes)
     }));
 }
 

--- a/src/codegen/languages/java.ts
+++ b/src/codegen/languages/java.ts
@@ -1,4 +1,4 @@
-import { Class, Property, File, getCommentHeader } from "../types";
+import { Class, Property, File, getCommentHeader, Context } from "../types";
 import { GenerateOptions } from "../api";
 
 const typeMaps = {
@@ -37,8 +37,8 @@ const typeInitializer = {
  * C# Code Generator
  */
 
-export function generate (classes: Class[], options: GenerateOptions): File[] {
-    return classes.map(klass => ({
+export function generate (context: Context, options: GenerateOptions): File[] {
+    return context.classes.map(klass => ({
         name: klass.name + ".java",
         content: generateClass(klass, options.namespace)
     }));

--- a/src/codegen/languages/js.ts
+++ b/src/codegen/languages/js.ts
@@ -1,4 +1,4 @@
-import { Class, Property, File, getCommentHeader, getInheritanceTree } from "../types";
+import { Class, Property, File, getCommentHeader, getInheritanceTree, Context } from "../types";
 import { GenerateOptions } from "../api";
 
 const typeMaps = {
@@ -19,10 +19,10 @@ const typeMaps = {
 
 const distinct = (value, index, self) => self.indexOf(value) === index;
 
-export function generate (classes: Class[], options: GenerateOptions): File[] {
-    return classes.map(klass => ({
+export function generate (context: Context, options: GenerateOptions): File[] {
+    return context.classes.map(klass => ({
         name: klass.name + ".js",
-        content: generateClass(klass, options.namespace, classes)
+        content: generateClass(klass, options.namespace, context.classes)
     }));
 }
 

--- a/src/codegen/languages/lua.ts
+++ b/src/codegen/languages/lua.ts
@@ -1,4 +1,4 @@
-import { Class, Property, File, getCommentHeader, getInheritanceTree } from "../types";
+import { Class, Property, File, getCommentHeader, getInheritanceTree, Context } from "../types";
 import { GenerateOptions } from "../api";
 
 /**
@@ -25,10 +25,10 @@ const typeMaps = {
 
 const distinct = (value, index, self) => self.indexOf(value) === index;
 
-export function generate (classes: Class[], options: GenerateOptions): File[] {
-    return classes.map(klass => ({
+export function generate (context: Context, options: GenerateOptions): File[] {
+    return context.classes.map(klass => ({
         name: klass.name + ".lua",
-        content: generateClass(klass, options.namespace, classes)
+        content: generateClass(klass, options.namespace, context.classes)
     }));
 }
 

--- a/src/codegen/languages/ts.ts
+++ b/src/codegen/languages/ts.ts
@@ -1,4 +1,4 @@
-import { Class, Property, File, getCommentHeader, getInheritanceTree } from "../types";
+import { Class, Property, File, getCommentHeader, getInheritanceTree, Context } from "../types";
 import { GenerateOptions } from "../api";
 
 const typeMaps = {
@@ -19,10 +19,10 @@ const typeMaps = {
 
 const distinct = (value, index, self) => self.indexOf(value) === index;
 
-export function generate (classes: Class[], options: GenerateOptions): File[] {
-    return classes.map(klass => ({
+export function generate (context: Context, options: GenerateOptions): File[] {
+    return context.classes.map(klass => ({
         name: klass.name + ".ts",
-        content: generateClass(klass, options.namespace, classes)
+        content: generateClass(klass, options.namespace, context.classes)
     }));
 }
 

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -14,26 +14,36 @@ export function getCommentHeader(singleLineComment: string = "//") {
 
 export class Context {
     classes: Class[] = [];
+    interfaces: Interface[] = [];
 
-    getSchemaClasses() {
-        return this.classes.filter(klass => {
-            if (this.isSchemaClass(klass)) {
-                return true;
-            } else {
-                let parentClass = klass;
-                while (parentClass = this.getParentClass(parentClass)) {
-                    if (this.isSchemaClass(parentClass)) {
-                        return true;
+    getStructures() {
+        return {
+            classes: this.classes.filter(klass => {
+                if (this.isSchemaClass(klass)) {
+                    return true;
+                } else {
+                    let parentClass = klass;
+                    while (parentClass = this.getParentClass(parentClass)) {
+                        if (this.isSchemaClass(parentClass)) {
+                            return true;
+                        }
                     }
                 }
-            }
-            return false;
-        });
+                return false;
+            }),
+            interfaces: this.interfaces,
+        };
     }
 
-    addClass(currentClass: Class) {
-        currentClass.context = this;
-        this.classes.push(currentClass);
+    addStructure(structure: IStructure) {
+        structure.context = this;
+
+        if (structure instanceof Class) {
+            this.classes.push(structure);
+
+        } else if (structure instanceof Interface) {
+            this.interfaces.push(structure);
+        }
     }
 
     private getParentClass(klass: Class) {
@@ -53,7 +63,24 @@ export class Context {
     }
 }
 
-export class Class {
+export interface IStructure {
+    context: Context;
+    name: string;
+    properties: Property[];
+    addProperty(property: Property);
+}
+
+export class Interface implements IStructure {
+    context: Context;
+    name: string;
+    properties: Property[] = [];
+
+    addProperty(property: Property) {
+        this.properties.push(property);
+    }
+}
+
+export class Class implements IStructure {
     context: Context;
     name: string;
     properties: Property[] = [];


### PR DESCRIPTION
With Colyseus 0.13 coming out, and [the new type-safe Send()/OnMessage() feature](https://github.com/colyseus/colyseus-unity3d/issues/113), it would be nice to avoid manually creating the same structures on both server-side and client-side in order for them to communicate.

The problem with generating classes for EVERY interface is that the `schema-codegen` may generate code for interfaces that aren't really related to message passing.

The ideal example of this feature is this:

```typescript
interface SomeMessageType {
  bar: number;
}

//...

this.onMessage("foo", (client, message: SomeMessageType) => {
  // received `SomeMessageType`
});
```

And in the client-side (C#) you can use the generated class to send a message:

```csharp
room.Send("foo", new SomeMessageType { bar = 10 })
```