### PR TITLE
failing test for map digit index bug

### DIFF
--- a/test/EdgeCasesTest.ts
+++ b/test/EdgeCasesTest.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import * as nanoid from "nanoid";
 import { MapSchema, Schema, type, ArraySchema } from "../src";
 
-import { State, Player } from "./Schema";
+import { State, Player, DeepEntity, DeepState2, Another } from "./Schema";
 
 describe("Edge cases", () => {
 
@@ -116,5 +116,34 @@ describe("Edge cases", () => {
 
         decodedState3.decode(state.encode());
         assert.equal(JSON.stringify(decodedState3), JSON.stringify(decodedState4));
+    });
+
+    
+    it("MapSchema: deep entities by index begining with non-zero number", () => {
+        const idx1 = 'd';
+        const idx2 = '7'; // has to start with a digit 1-9
+        const state = new DeepState2();
+
+        state.mapOfEntities = new MapSchema<Another>();
+
+        const e1 = new Another(); 
+        state.mapOfEntities[idx1] = e1;
+
+        const e2 = new Another(); 
+        state.mapOfEntities[idx2] = e2; 
+
+        state.encodeAll();
+
+        const state1 = new DeepState2();
+        state1.decode(state.encodeAll());
+
+        
+        for (let i = 0; i < 100; i++) {
+            state.mapOfEntities[idx2].position.x += 100;
+            state.mapOfEntities[idx1].position.x -= 100;
+            state1.decode(state.encode());
+        }
+
+        assert.equal(JSON.stringify(state1.mapOfEntities['d']), JSON.stringify(state.mapOfEntities['d']));
     });
 });

--- a/test/Schema.ts
+++ b/test/Schema.ts
@@ -85,6 +85,11 @@ export class DeepState extends Schema {
   map = new MapSchema<DeepMap>();
 }
 
+export class DeepState2 extends Schema {
+
+  @type({ map: Another })
+  mapOfEntities: MapSchema<Another>;
+}
 
 /**
  * Filters example


### PR DESCRIPTION
This PR is a bug report of a sneaky edge case. Added a failing test, where an index in `MapSchema` that starts with a digit character (not 0) result with swapping between deep state of values.

at the end of the new test, in `state1`  the values in the `.position` fields of the entities will be opposite to the value in `state` (`state1.mapOfEntities['d']` will have the state of `state.mapOfEntities['7']` and the other way around)

I'd have loved to suggest a fix but I give up