### PR TITLE
Fix TS1263 in typescript code generation.

### DIFF
--- a/src/codegen/languages/ts.ts
+++ b/src/codegen/languages/ts.ts
@@ -104,7 +104,9 @@ function generateProperty(prop: Property) {
         typeArgs = `"${prop.type}"`;
     }
 
-    return `@type(${typeArgs}) public ${prop.name}!: ${langType}${(initializer) ? ` = ${initializer}` : ""};`
+    const definiteAssertion = initializer ? "" : "!";
+
+    return `@type(${typeArgs}) public ${prop.name}${definiteAssertion}: ${langType}${(initializer) ? ` = ${initializer}` : ""};`
 }
 
 


### PR DESCRIPTION
The typescript code generation currently adds a definite assignment assertion (`!`) to all properties.
However, as [TS1263 ](https://github.com/microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json#L866) specifies, this is not allowed for declarations with initializers.

This pull request fixes the issue and adds the definite assignment assertion only when no initialization takes place.