### PR TITLE
Improve errormessage when calling MapSchema.set(key, undefined)

### DIFF
--- a/src/types/MapSchema.ts
+++ b/src/types/MapSchema.ts
@@ -82,6 +82,10 @@ export class MapSchema<V=any> implements Map<string, V>, SchemaDecoderCallbacks 
     get [Symbol.toStringTag]() { return this.$items[Symbol.toStringTag] }
 
     set(key: string, value: V) {
+    		if (value === undefined || value === null) {
+            throw new Error('Value cant be undefined');
+        }
+
         // get "index" for this value.
         const hasIndex = typeof(this.$changes.indexes[key]) !== "undefined";
         const index = (hasIndex)


### PR DESCRIPTION
When calling MapSchema.set(key, undefined), the resulting error message is not really descriptive (TypeError: Cannot read property '$changes' of undefined, MapSchema.ts:95). In my opinion, the value should be checked for and an assertion or a dedicated error should be thrown.