### PR TITLE
Push filtered bytes instead of concat for 100x better performance

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -806,7 +806,7 @@ export abstract class Schema {
                         //
                         // use cached bytes directly if is from Schema type.
                         //
-                        filteredBytes = filteredBytes.concat(changeTree.caches[fieldIndex]);
+                        filteredBytes.push.apply(filteredBytes, changeTree.caches[fieldIndex] || [undefined]);
                         containerIndexes.add(fieldIndex);
 
                     } else {
@@ -814,7 +814,7 @@ export abstract class Schema {
                             //
                             // use cached bytes if already has the field
                             //
-                            filteredBytes = filteredBytes.concat(changeTree.caches[fieldIndex]);
+                            filteredBytes.push.apply(filteredBytes, changeTree.caches[fieldIndex] || [undefined]);
 
                         } else {
                             //


### PR DESCRIPTION
Hey, greetings from [Teamflow](https://www.teamflowhq.com)!

# Change

TLDR; Using `push()` instead of `concat()` saves lots of CPU time when the state is large.

# Context

We started using `@filter`/`@filterChildren` and noticed a very steep drop in server performance when the state was large. When testing with ~900 furniture objects with ~10 fields per object, `applyFilters` took 6 seconds on my 3.6 GHz Core i9 processor:

<img width="1040" alt="screen_shot_2021-05-26_at_3 48 06_pm" src="https://user-images.githubusercontent.com/22450567/119740663-4b02c300-be52-11eb-9fa1-54f855a056d2.png">

When I dug into this, found that Array concatenation itself was taking 4.6 seconds:

<img width="844" alt="screen_shot_2021-05-26_at_5 28 27_pm" src="https://user-images.githubusercontent.com/22450567/119740887-acc32d00-be52-11eb-9ca7-460bed0fa317.png">

Using concatenation causes excessive copying of larger and larger arrays as the loop progresses, making it an O(n²) operation instead of O(n). By pushing the bytes into the same array, it performance 100x faster and finishes in less than 60ms:

<img width="537" alt="screen_shot_2021-05-26_at_5 48 20_pm" src="https://user-images.githubusercontent.com/22450567/119740820-8ef5c800-be52-11eb-90a3-f372d1c6cbb4.png">

