### PR TITLE
Add precondition to check that `type` is defined

### DIFF
--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -167,6 +167,10 @@ export const globalContext = new Context();
  */
 export function type (type: DefinitionType, context: Context = globalContext): PropertyDecorator {
     return function (target: typeof Schema, field: string) {
+        if (!type) {
+            throw new Error("Type not found. Ensure your `@type` annotations are correct and that you don't have any circular dependencies.");
+        }
+        
         const constructor = target.constructor as typeof Schema;
         constructor._context = context;
 


### PR DESCRIPTION
I hit this issue due to a circular dependency, and it took me hours to debug, partially because the current error only gets reported after following this call stack even though the issue wasn't related to an `ArraySchema`:

https://github.com/colyseus/schema/blob/04cde2e589fc8b02267d055716873db98c58a840/src/annotations.ts#L204
https://github.com/colyseus/schema/blob/04cde2e589fc8b02267d055716873db98c58a840/src/types/ArraySchema.ts#L102