### PR TITLE
import CustomSchema dependencies for SetSchema<CustomSchema> props

### DIFF
--- a/src/codegen/languages/ts.ts
+++ b/src/codegen/languages/ts.ts
@@ -38,7 +38,7 @@ function generateClass(klass: Class, namespace: string, allClasses: Class[]) {
         let type = property.type;
 
         // keep all refs list
-        if ((type === "ref" || type === "array" || type === "map")) {
+        if ((type === "ref" || type === "array" || type === "map" || type === "set")) {
             allRefs.push(property);
         }
     });


### PR DESCRIPTION
Fix for generating TS client schemas.

Without is SetSchema dependencies are not imported:

server:
```typescript
import {Schema, type, SetSchema} from '@colyseus/schema';
import {CustomSchema} from './custom';

class Foo extends Schema {
  @type({set: CustomSchema}) bar = new SetSchema<CustomSchema>();
}
```

client:
```typescript
import {Schema, type, SetSchema} from '@colyseus/schema';
//  missing: import {CustomSchema} from './custom';

class Foo extends Schema {
  @type({set: CustomSchema}) bar = new SetSchema<CustomSchema>();
}
```
