### PR TITLE
feat: extends extensions of files for codegen

### DIFF
--- a/src/codegen/parser.ts
+++ b/src/codegen/parser.ts
@@ -210,7 +210,8 @@ export function parseFiles(
         if (
             !fileName.endsWith(".ts") &&
             !fileName.endsWith(".js") &&
-            !fileName.endsWith(".mjs")
+            !fileName.endsWith(".mjs") &&
+            !fileName.endsWith(".msg")
         ) {
             fileNameAlternatives.push(`${fileName}.ts`);
             fileNameAlternatives.push(`${fileName}/index.ts`);


### PR DESCRIPTION
The problem is message with integer, but we can declare custom types only for schemas, and interfaces can't use decorators, so below code will always generate float type
 
use-card.message.ts
```
export interface UseCardMessage {
  cardId: string;
  targetSlot?: number;
}
```

Solution is to change extension of declaration of messages to .msg to hide error message from linters and etc. And now we can declare custom types

use-card.message.msg
```
export interface UseCardMessage {
  cardId: string;
  targetSlot?: int32;
}
```