### PR TITLE
Apply glob in codegen cli script instead relying on OS/shell support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "benchmark": "^2.1.4",
     "flatbuffers": "^1.10.2",
     "fossil-delta": "^1.0.2",
-    "glob": "^7.1.5",
     "mocha": "^5.2.0",
     "nanoid": "^3.1.10",
     "notepack.io": "^2.2.0",
@@ -92,5 +91,8 @@
       "lcov"
     ],
     "all": true
+  },
+  "dependencies": {
+    "glob": "^7.1.5"
   }
 }

--- a/src/codegen/cli.ts
+++ b/src/codegen/cli.ts
@@ -1,3 +1,4 @@
+import * as glob from "glob";
 import argv from "./argv";
 import { generate } from "./api";
 
@@ -50,9 +51,9 @@ if (!args.output) {
 }
 
 try {
-    args.files = args._;
+    args.files = [].concat(...args._.map((filename) => glob.sync(filename)));
     generate(targetId, {
-        files: args._,
+        files: args.files,
         decorator: args.decorator,
         output: args.output,
         namespace: args.namespace


### PR DESCRIPTION
In its current version, the codegen cli script relies on the respective shell to expand globs for code generation. This does, for example, not work in a windows cmd.

This PR uses the glob package (had already been a dev-dependency) to parse globs in case they were not yet expanded by the shell.