### PR TITLE
add key type to MapSchema

### DIFF
--- a/src/types/MapSchema.ts
+++ b/src/types/MapSchema.ts
@@ -1,6 +1,7 @@
+import { Schema, SchemaDecoderCallbacks } from "../Schema";
+
 import { ChangeTree } from "../changes/ChangeTree";
 import { OPERATION } from "../spec";
-import { SchemaDecoderCallbacks, Schema } from "../Schema";
 
 export function getMapProxy(value: MapSchema) {
     value['$proxy'] = true;
@@ -45,26 +46,26 @@ export function getMapProxy(value: MapSchema) {
     return value;
 }
 
-export class MapSchema<V=any> implements Map<string, V>, SchemaDecoderCallbacks {
+export class MapSchema<V=any, K extends string = string> implements Map<K, V>, SchemaDecoderCallbacks {
     protected $changes: ChangeTree = new ChangeTree(this);
 
-    protected $items: Map<string, V> = new Map<string, V>();
-    protected $indexes: Map<number, string> = new Map<number, string>();
+    protected $items: Map<K, V> = new Map<K, V>();
+    protected $indexes: Map<number, K> = new Map<number, K>();
 
     protected $refId: number = 0;
 
     //
     // Decoding callbacks
     //
-    public onAdd?: (item: V, key: string) => void;
-    public onRemove?: (item: V, key: string) => void;
-    public onChange?: (item: V, key: string) => void;
+    public onAdd?: (item: V, key: K) => void;
+    public onRemove?: (item: V, key: K) => void;
+    public onChange?: (item: V, key: K) => void;
 
     static is(type: any) {
         return type['map'] !== undefined;
     }
 
-    constructor (initialValues?: Map<string, V> | any) {
+    constructor (initialValues?: Map<K, V> | Record<K, V>) {
         if (initialValues) {
             if (initialValues instanceof Map) {
                 initialValues.forEach((v, k) => this.set(k, v));
@@ -78,10 +79,10 @@ export class MapSchema<V=any> implements Map<string, V>, SchemaDecoderCallbacks 
     }
 
     /** Iterator */
-    [Symbol.iterator](): IterableIterator<[string, V]> { return this.$items[Symbol.iterator](); }
+    [Symbol.iterator](): IterableIterator<[K, V]> { return this.$items[Symbol.iterator](); }
     get [Symbol.toStringTag]() { return this.$items[Symbol.toStringTag] }
 
-    set(key: string, value: V) {
+    set(key: K, value: V) {
         if (value === undefined || value === null) {
             throw new Error(`MapSchema#set('${key}', ${value}): trying to set ${value} value on '${key}'.`);
         }
@@ -127,11 +128,11 @@ export class MapSchema<V=any> implements Map<string, V>, SchemaDecoderCallbacks 
         return this;
     }
 
-    get(key: string): V | undefined {
+    get(key: K): V | undefined {
         return this.$items.get(key);
     }
 
-    delete(key: string) {
+    delete(key: K) {
         //
         // TODO: add a "purge" method after .encode() runs, to cleanup removed `$indexes`
         //
@@ -169,11 +170,11 @@ export class MapSchema<V=any> implements Map<string, V>, SchemaDecoderCallbacks 
         this.$changes.touchParents();
     }
 
-    has (key: string) {
+    has (key: K) {
         return this.$items.has(key);
     }
 
-    forEach(callbackfn: (value: V, key: string, map: Map<string, V>) => void) {
+    forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void) {
         this.$items.forEach(callbackfn);
     }
 
@@ -193,7 +194,7 @@ export class MapSchema<V=any> implements Map<string, V>, SchemaDecoderCallbacks 
         return this.$items.size;
     }
 
-    protected setIndex(index: number, key: string) {
+    protected setIndex(index: number, key: K) {
         this.$indexes.set(index, key);
     }
 


### PR DESCRIPTION
I took the librety of suggesting a solution to a problem I faced while using Colyseus, without opening an issue first. 

In my state I have maps of optional overrides for certain properties. each map can have properties from a certain static list. 
I'd like to have Typescript aware key type in MapSchema, so only the desired properties can be written into the map.

This change:
allow more restrictive key type (subset of string) 
not changing any runtime (javascript) code.
default behavior is same as before change.

The one thing that can break backward compatibility is I've changed the constructor argument type to not accept `any`. I see it as an improvement but I can easily undo it if it's an issue.
