### PR TITLE
check for null before calling `this[field].clone()` in `Schema.clone()`

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -878,7 +878,7 @@ export abstract class Schema {
         for (let field in schema) {
             if (
                 typeof (this[field]) === "object" &&
-                typeof (this[field].clone) === "function"
+                typeof (this[field]?.clone) === "function"
             ) {
                 // deep clone
                 cloned[field] = this[field].clone();


### PR DESCRIPTION
just encountered this
```

    TypeError: Cannot read properties of null (reading 'clone')

      at ShipState.Object.<anonymous>.Schema.clone (node_modules/@colyseus/schema/src/Schema.ts:881:37)
      at node_modules/@colyseus/schema/src/types/MapSchema.ts:242:51
          at Map.forEach (<anonymous>)
      at Proxy.Object.<anonymous>.MapSchema.forEach (node_modules/@colyseus/schema/src/types/MapSchema.ts:178:21)
      at Proxy.Object.<anonymous>.MapSchema.clone (node_modules/@colyseus/schema/src/types/MapSchema.ts:240:18)
      at GameStateFragment.Object.<anonymous>.Schema.clone (node_modules/@colyseus/schema/src/Schema.ts:884:45)
      at GameManager.saveGame (modules/server/src/admin/game-manager.ts:104:22)
      at modules/server/src/server.ts:37:35
...
```