### PR TITLE
suggestion: add "src" to published package for debugability

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prepublishOnly": "npm run build"
   },
   "files": [
+    "src",
     "lib",
     "build",
     "bin"


### PR DESCRIPTION
This will increase package size from 1.32MB to 1.45MB, but will allow users that debug with sourcemaps to easily navigate into the code.