### PR TITLE
bug in MapSchema encode?

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -437,6 +437,7 @@ export abstract class Schema {
 
                     // ref.set(key, value);
                     ref['$items'].set(key, value);
+                    ref['$changes'].allChanges.add(fieldIndex);
 
                 } else if (ref instanceof ArraySchema) {
                     // const key = ref['$indexes'][field];

--- a/test/SchemaTest.ts
+++ b/test/SchemaTest.ts
@@ -948,6 +948,27 @@ describe("Schema Usage", () => {
             delete state.mapOfPlayers['jake'];
         });
 
+        it('should encode map with primitive values from decoded state', () => {
+            class TestMapSchema extends Schema {
+                @type({ map: 'number' })
+                value = new MapSchema<number>();
+            }
+            const state = new TestMapSchema();
+
+            state.value.set('k1', 1);
+            const firstEncoded = state.encodeAll();
+            
+            const decodedState1 = new TestMapSchema();
+            decodedState1.decode(firstEncoded);
+            assert.deepStrictEqual(decodedState1.toJSON(), state.toJSON(), `decodedState1.toJSON() EQ state.toJSON()`);
+            const secondEncoded = decodedState1.encodeAll();
+            assert.deepStrictEqual(secondEncoded, firstEncoded, `firstEncoded EQ secondEncoded`);
+
+            const decodedState2 = new TestMapSchema();
+            decodedState2.decode(secondEncoded);
+            assert.deepStrictEqual(decodedState2.toJSON(), state.toJSON(), `decodedState2.toJSON() EQ state.toJSON()`);
+        });
+
         it('should discard deleted map items', () => {
             class Player extends Schema {
                 @type("number")


### PR DESCRIPTION
re-encoding a MapSchema with primitive values fails. added a failing test but could not grasp the changeTree mechanism enough to fix it.