### PR TITLE
Generate "enums" from schema for Unity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ package-lock.json
 
 # Tests
 coverage/
+.nyc_output/
 
 # Mac
 .DS_Store

--- a/src/codegen/languages/csharp.ts
+++ b/src/codegen/languages/csharp.ts
@@ -1,4 +1,11 @@
-import { Class, Property, File, getCommentHeader, Interface } from "../types";
+import {
+    Class,
+    Property,
+    File,
+    getCommentHeader,
+    Interface,
+    Enum,
+} from "../types";
 import { GenerateOptions } from "../api";
 import { Context } from "../types";
 
@@ -34,8 +41,12 @@ export function generate (context: Context, options: GenerateOptions): File[] {
         })),
         ...context.interfaces.map(structure => ({
             name: `${structure.name}.cs`,
-            content: generateInterface(structure, options.namespace)
-        }))
+            content: generateInterface(structure, options.namespace),
+        })),
+        ...context.enums.map((structure) => ({
+            name: `${structure.name}.cs`,
+            content: generateEnum(structure, options.namespace),
+        })),
     ];
 }
 
@@ -46,7 +57,23 @@ function generateClass(klass: Class, namespace: string) {
 using Colyseus.Schema;
 ${namespace ? `\nnamespace ${namespace} {` : ""}
 ${indent}public partial class ${klass.name} : ${klass.extends} {
-${klass.properties.map(prop => generateProperty(prop, indent)).join("\n\n")}
+${klass.properties.map((prop) => generateProperty(prop, indent)).join("\n\n")}
+${indent}}
+${namespace ? "}" : ""}
+`;
+}
+
+function generateEnum(_enum: Enum, namespace: string) {
+    const indent = namespace ? "\t" : "";
+    return `${getCommentHeader()}
+
+${namespace ? `\nnamespace ${namespace} {` : ""}
+${indent}public enum ${_enum.name} {
+${_enum.properties
+    .map(
+        (prop) => `${indent}\t${prop.name}${prop.type ? ` = ${prop.type}` : ""}`
+    )
+    .join(",\n\n")}
 ${indent}}
 ${namespace ? "}" : ""}
 `;

--- a/src/codegen/languages/csharp.ts
+++ b/src/codegen/languages/csharp.ts
@@ -69,14 +69,25 @@ ${namespace ? "}" : ""}
 
 function generateEnum(_enum: Enum, namespace: string) {
     const indent = namespace ? "\t" : "";
+    let enumRunningValue = 0;
     return `${getCommentHeader()}
-
 ${namespace ? `\nnamespace ${namespace} {` : ""}
-${indent}public enum ${_enum.name} {
+${indent}struct ${_enum.name} {
 ${_enum.properties
-    .map(
-        (prop) => `${indent}\t${prop.name}${prop.type ? ` = ${prop.type}` : ""}`
-    )
+    .map((prop) => {
+        const type = prop.type?.replace(/'/g, '"');
+        const isNumeric = /[0-9]+/.test(type);
+        if (isNumeric || type === undefined) {
+            if (type !== undefined) {
+                enumRunningValue = Number.parseInt(type, 10);
+            }
+            return `${indent}\tpublic const ${
+                prop.name
+            } = ${enumRunningValue++}`;
+        } else {
+            return `${indent}\tpublic const ${prop.name} = ${type}`;
+        }
+    })
     .join(",\n\n")}
 ${indent}}
 ${namespace ? "}" : ""}

--- a/src/codegen/languages/csharp.ts
+++ b/src/codegen/languages/csharp.ts
@@ -72,23 +72,21 @@ function generateEnum(_enum: Enum, namespace: string) {
     let enumRunningValue = 0;
     return `${getCommentHeader()}
 ${namespace ? `\nnamespace ${namespace} {` : ""}
-${indent}struct ${_enum.name} {
+${indent}public struct ${_enum.name} {
 ${_enum.properties
     .map((prop) => {
-        const type = prop.type?.replace(/'/g, '"');
-        const isNumeric = /[0-9]+/.test(type);
-        if (isNumeric || type === undefined) {
-            if (type !== undefined) {
-                enumRunningValue = Number.parseInt(type, 10);
+        const initializer = prop.type?.replace(/'/g, '"');
+        const isNumeric = /[0-9]+/.test(initializer);
+        if (isNumeric) {
+            enumRunningValue = Number.parseInt(initializer, 10);
             }
-            return `${indent}\tpublic const ${
-                prop.name
-            } = ${enumRunningValue++}`;
-        } else {
-            return `${indent}\tpublic const ${prop.name} = ${type}`;
-        }
+        const showAsInt = isNumeric || initializer === undefined;
+        const typeStr = showAsInt ? "int" : "string";
+        return `${indent}\tpublic const ${typeStr} ${prop.name} = ${
+            initializer ?? ++enumRunningValue
+        };\n`;
     })
-    .join(",\n\n")}
+    .join("")}
 ${indent}}
 ${namespace ? "}" : ""}
 `;

--- a/src/codegen/languages/csharp.ts
+++ b/src/codegen/languages/csharp.ts
@@ -69,24 +69,27 @@ ${namespace ? "}" : ""}
 
 function generateEnum(_enum: Enum, namespace: string) {
     const indent = namespace ? "\t" : "";
-    let enumRunningValue = 0;
+    let runningEnumValue = -1;
     return `${getCommentHeader()}
 ${namespace ? `\nnamespace ${namespace} {` : ""}
-${indent}public struct ${_enum.name} {
+${indent}public class ${_enum.name} {
+    \t${indent}private ${_enum.name}(object value) { Value = value; }
+
+    \t${indent}public object Value { get; private set; }
+
 ${_enum.properties
     .map((prop) => {
         const initializer = prop.type?.replace(/'/g, '"');
-        const isNumeric = /[0-9]+/.test(initializer);
-        if (isNumeric) {
-            enumRunningValue = Number.parseInt(initializer, 10);
+            if (/^[0-9]+$/.test(initializer)) {
+                runningEnumValue = parseInt(initializer);
             }
-        const showAsInt = isNumeric || initializer === undefined;
-        const typeStr = showAsInt ? "int" : "string";
-        return `${indent}\tpublic const ${typeStr} ${prop.name} = ${
-            initializer ?? ++enumRunningValue
-        };\n`;
+            return `\t${indent}public static ${_enum.name} ${
+                prop.name
+            } { get { return new ${_enum.name}(${
+                initializer ?? ++runningEnumValue
+            }); } }`;
     })
-    .join("")}
+        .join("\n")}
 ${indent}}
 ${namespace ? "}" : ""}
 `;

--- a/src/codegen/languages/csharp.ts
+++ b/src/codegen/languages/csharp.ts
@@ -33,7 +33,11 @@ const capitalize = (s) => {
     return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-export function generate (context: Context, options: GenerateOptions): File[] {
+export function generate(context: Context, options: GenerateOptions): File[] {
+    // enrich typeMaps with enums
+    context.enums.forEach((structure) => {
+        typeMaps[structure.name] = structure.name;
+    });
     return [
         ...context.classes.map(structure => ({
             name: `${structure.name}.cs`,

--- a/src/codegen/parser.ts
+++ b/src/codegen/parser.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import * as path from "path";
 import { readFileSync } from "fs";
-import { IStructure, Class, Interface, Property, Context } from "./types";
+import { IStructure, Class, Interface, Property, Context, Enum } from "./types";
 
 let currentStructure: IStructure;
 let currentProperty: Property;
@@ -60,6 +60,18 @@ function inspectNode(node: ts.Node, context: Context, decoratorName: string) {
 
                 context.addStructure(currentStructure);
             }
+            break;
+
+        case ts.SyntaxKind.EnumDeclaration:
+            const enumName = (
+                node as ts.EnumDeclaration
+            ).name.escapedText.toString();
+            if (enumName.indexOf("Type") === -1) {
+                break;
+            }
+            currentStructure = new Enum();
+            currentStructure.name = enumName;
+            context.addStructure(currentStructure);
             break;
 
         case ts.SyntaxKind.ExtendsKeyword:
@@ -180,6 +192,20 @@ function inspectNode(node: ts.Node, context: Context, decoratorName: string) {
 
             currentProperty = undefined;
 
+            break;
+
+        case ts.SyntaxKind.EnumMember:
+            if (currentStructure instanceof Enum) {
+                const initializer = (node as any).initializer?.getText();
+                const name = node.getFirstToken().getText();
+                const property = currentProperty || new Property();
+                property.name = name;
+                if (initializer !== undefined) {
+                    property.type = initializer;
+                }
+                currentStructure.addProperty(property);
+                currentProperty = undefined;
+            }
             break;
     }
 

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -15,6 +15,7 @@ export function getCommentHeader(singleLineComment: string = "//") {
 export class Context {
     classes: Class[] = [];
     interfaces: Interface[] = [];
+    enums: Enum[] = [];
 
     getStructures() {
         return {
@@ -33,6 +34,7 @@ export class Context {
                 return false;
             }),
             interfaces: this.interfaces,
+            enums: this.enums,
         };
     }
 
@@ -41,9 +43,10 @@ export class Context {
 
         if (structure instanceof Class) {
             this.classes.push(structure);
-
         } else if (structure instanceof Interface) {
             this.interfaces.push(structure);
+        } else if (structure instanceof Enum) {
+            this.enums.push(structure);
         }
     }
 
@@ -131,6 +134,16 @@ export class Class implements IStructure {
                 prop.index += parentKlass.properties.length;
             });
         }
+    }
+}
+
+export class Enum implements IStructure {
+    context: Context;
+    name: string;
+    properties: Property[] = [];
+
+    addProperty(property: Property) {
+        this.properties.push(property);
     }
 }
 

--- a/test/codegen/CodegenTest.ts
+++ b/test/codegen/CodegenTest.ts
@@ -61,11 +61,25 @@ describe("schema-codegen", () => {
     });
 
     it("should support generating abstract classes with no fields", async () => {
-        const inputFiles = glob.sync(path.resolve(INPUT_DIR, "AbstractSchema.ts"));
+        const inputFiles = glob.sync(
+            path.resolve(INPUT_DIR, "AbstractSchema.ts")
+        );
 
         generate("csharp", {
             files: inputFiles,
-            output: OUTPUT_DIR
+            output: OUTPUT_DIR,
+        });
+
+        const outputFiles = glob.sync(path.resolve(OUTPUT_DIR, "*.cs"));
+        assert.strictEqual(2, outputFiles.length);
+    });
+
+    it("should support generating enums", async () => {
+        const inputFiles = glob.sync(path.resolve(INPUT_DIR, "Enums.ts"));
+
+        generate("csharp", {
+            files: inputFiles,
+            output: OUTPUT_DIR,
         });
 
         const outputFiles = glob.sync(path.resolve(OUTPUT_DIR, "*.cs"));

--- a/test/codegen/sources/Enums.ts
+++ b/test/codegen/sources/Enums.ts
@@ -1,0 +1,12 @@
+// Example data
+
+export enum ShipType {
+    Transport,
+    Miner,
+    Colonizer,
+}
+
+export enum MessageType {
+    DeployMiner = "deploy-miner",
+    ColonizePlanet = "colonize-planet",
+}


### PR DESCRIPTION
Hi, this seems to work. I'd be happy to discuss and change the solution and code.

 - I might have abused the `Property`'s type as an initializer for an enum entry. It's a bit smelly.
 - The "enum" class solution was taken from here: https://stackoverflow.com/a/1343517/2242159
 - I decided to check for "Type" string in the enum name to include it, similar to that undocumented "Message" thing for interfaces.
 - It's only implemented for C# here

It works for me on my project. I think. For example, I have these generated:

```csharp
public class ShipType {
    private ShipType(object value) { Value = value; }

    public object Value { get; private set; }

    public static ShipType Transporter { get { return new ShipType("transport"); } }
    public static ShipType Miner { get { return new ShipType("miner"); } }
    public static ShipType Colonizer { get { return new ShipType("colonizer"); } }
}
```

```csharp
public class BuildShipMessageData {
    public string atPlanetId;
    public float slotIndex;
    public ShipType shipType;  // Note that the "Enum" is used here
}
```

```csharp
public class GameMessageType {
    private GameMessageType(object value) { Value = value; }

    public object Value { get; private set; }

    public static GameMessageType buildSlot { get { return new GameMessageType(0); } }
    public static GameMessageType scrapSlot { get { return new GameMessageType(1); } }
    public static GameMessageType buildShip { get { return new GameMessageType(2); } }
    public static GameMessageType deployMiner { get { return new GameMessageType(3); } }
}
```

(ignore the namespace I omitted from the previous snippets)
![image](https://user-images.githubusercontent.com/1746811/184474523-7e058355-fb3a-420a-bd45-dcd5f14971d4.png)

And I had to use `.ToString()` for the room messages:
![image](https://user-images.githubusercontent.com/1746811/184474544-8f4327fb-6650-418d-8bee-7b16dbfb6ff5.png)



