### PR TITLE
fix: improve experience for module resolution node16+ package type "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     ".": {
       "browser": "./build/umd/index.js",
       "import": "./build/esm/index.mjs",
-      "require": "./build/cjs/index.js"
+      "require": "./build/cjs/index.js",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
TypeScirpt 4.8.4
Node v16.15.1
@colyseus/schema 1.0.41

---

While upgrading my game packages to ES modules with TS setting `"moduleResolution": "NodeNext"` I discovered I was missing types for everything `@colyseus/schema` was exporting. In my IDE (VsCode), there were no types for properties of `MapSchema`, which itself was seen as type `any`. Then, in build time it was also the case - `tsc` was silently ignoring, or was blind to the types of Schema.

I made a reproduction repo with two cases (inspect comments in `src/*.ts` files):

1. [pkgCommonjs](https://github.com/Zielak/coly-schema-esm-test/tree/main/pkgCommonjs) - setup the default way
2. [pkgModule](https://github.com/Zielak/coly-schema-esm-test/tree/main/pkgModule) - setup with `"type": "module"` in package.json, and `"moduleResolution": "NodeNext"` in tsconfig.

https://github.com/Zielak/coly-schema-esm-test

Seems TS is ignoring the "global" _types_ field in presence of "exports", where the consumer is setup to be ES module.

Tested locally: added the field like in this PR, restarted TS and everything worked as expected.