### PR TITLE
fix: ArraySchema.with return value should be ArraySchema

### DIFF
--- a/src/types/ArraySchema.ts
+++ b/src/types/ArraySchema.ts
@@ -605,7 +605,7 @@ export class ArraySchema<V = any> implements Array<V>, SchemaDecoderCallbacks {
     //
     // ES2023
     //
-    with(index: number, value: V): V[] {
+    with(index: number, value: V): ArraySchema<V> {
         const copy = Array.from(this.$items.values());
         copy[index] = value;
         return new ArraySchema(...copy);


### PR DESCRIPTION
ArraySchema.with returns another ArraySchema so the type of its return value should be ArraySchema<V>
