### PR TITLE
fix ArraySchema#at with negative indexes

### DIFF
--- a/src/types/ArraySchema.ts
+++ b/src/types/ArraySchema.ts
@@ -167,6 +167,13 @@ export class ArraySchema<V = any> implements Array<V>, SchemaDecoderCallbacks {
         //
         // FIXME: this should be O(1)
         //
+        
+	    index = Math.trunc(index) || 0;
+	    // Allow negative indexing from the end
+	    if (index < 0) index += this.length;
+	    // OOB access is guaranteed to return undefined
+	    if (index < 0 || index >= this.length) return undefined;
+        
         const key = Array.from(this.$items.keys())[index];
         return this.$items.get(key);
     }

--- a/test/ArraySchema.test.ts
+++ b/test/ArraySchema.test.ts
@@ -1495,6 +1495,16 @@ describe("ArraySchema Tests", () => {
 
             assert.deepEqual([1,2,3], arr.toJSON());
         });
+
+        it("#at()", () => {
+            const arr = new ArraySchema<number>(1,2,3,4,5);
+            assert.strictEqual(1, arr.at(0));
+            assert.strictEqual(3, arr.at(2));
+            assert.strictEqual(5, arr.at(-1));
+            assert.strictEqual(1, arr.at(-5));
+            assert.strictEqual(undefined, arr.at(5));
+            assert.strictEqual(undefined, arr.at(-6));
+        });
     })
 
     describe("ArraySchema <-> Array type interchangability", () => {


### PR DESCRIPTION
This PR solves this problem:

- ArraySchema at() was not working with negative indexes

Solution:

complete at method of ArraySchema based on TC39 polyfill (https://github.com/tc39/proposal-relative-indexing-method?tab=readme-ov-file#polyfill)

Once the library will target ES2022 code, we can simplify the code to `Array.from(this.$items.keys()).at(index)`