### PR TITLE
fix: recursive ToJSON

### DIFF
--- a/src/types/HelperTypes.ts
+++ b/src/types/HelperTypes.ts
@@ -12,14 +12,18 @@ export type NonFunctionPropNames<T> = {
 
 type Primitive = string | number | bigint | boolean | symbol | undefined | null;
 
-export type ToJSON<T> = T extends Primitive ? T : NonFunctionProps<{
-    [K in keyof T]: T[K] extends MapSchema<infer U>
+export type ToJSON<T> =T extends Primitive
+    // Keep primitive values as-is, and do not omit their methods
+    ? T
+    // On objects, remove methods with NonFunctionProps
+    : NonFunctionProps<{
+        [K in keyof T]: T[K] extends MapSchema<infer U>
         ? Record<string, ToJSON<U>>
         : T[K] extends Map<string, infer U>
-            ? Record<string, ToJSON<U>>
-            : T[K] extends ArraySchema<infer U>
-                ? ToJSON<U>[]
-                : T[K] extends Schema
-                    ? ToJSON<T[K]>
-                    : T[K]
-}>
+        ? Record<string, ToJSON<U>>
+        : T[K] extends ArraySchema<infer U>
+        ? ToJSON<U>[]
+        : T[K] extends Schema
+        ? ToJSON<T[K]>
+        : T[K]
+    }>

--- a/src/types/HelperTypes.ts
+++ b/src/types/HelperTypes.ts
@@ -1,5 +1,6 @@
 import { ArraySchema } from "./ArraySchema";
 import { MapSchema } from "./MapSchema";
+import { Schema } from "../Schema";
 
 export type NonFunctionProps<T> = Omit<T, {
     [K in keyof T]: T[K] extends Function ? K : never;
@@ -9,12 +10,16 @@ export type NonFunctionPropNames<T> = {
     [K in keyof T]: T[K] extends Function ? never : K
 }[keyof T];
 
-export type ToJSON<T> = NonFunctionProps<{
+type Primitive = string | number | bigint | boolean | symbol | undefined | null;
+
+export type ToJSON<T> = T extends Primitive ? T : NonFunctionProps<{
     [K in keyof T]: T[K] extends MapSchema<infer U>
-        ? Record<string, U>
+        ? Record<string, ToJSON<U>>
         : T[K] extends Map<string, infer U>
-            ? Record<string, U>
+            ? Record<string, ToJSON<U>>
             : T[K] extends ArraySchema<infer U>
-                ? U[]
-                : T[K]
-}>;
+                ? ToJSON<U>[]
+                : T[K] extends Schema
+                    ? ToJSON<T[K]>
+                    : T[K]
+}>

--- a/test/helpers/Equals.ts
+++ b/test/helpers/Equals.ts
@@ -1,0 +1,7 @@
+// Used to check if two types are equal.
+// If they are equal, the expression evaluates to true, otherwise false
+export type Equals<T1, T2> = T1 extends T2
+    ? T2 extends T1
+        ? true
+        : false
+    : false

--- a/test/src/HelperTypes.test.ts
+++ b/test/src/HelperTypes.test.ts
@@ -1,0 +1,89 @@
+import {ArraySchema, MapSchema, Schema, ToJSON, type} from "../../src";
+import {Equals} from "../helpers/Equals";
+
+// Reused across multiple tests
+export class VecSchema extends Schema {
+    @type('number') x: number
+    @type('number') y: number
+}
+
+describe("ToJSON type tests", () => {
+    it("Omits methods", () => {
+        class C extends Schema {
+            @type('number') time: number
+            rewind(arg: number){}
+        }
+        const _t1: Equals<ToJSON<C>, {
+            time: number
+        }> = true
+    })
+
+    it("Does not transform primitive types", () => {
+        // Primitive types have methods, and these should not be omitted
+        const _tString: Equals<ToJSON<string>, string> = true
+        const _tNumber: Equals<ToJSON<number>, number> = true
+        const _tBoolean: Equals<ToJSON<boolean>, boolean> = true
+        const _tBigInt: Equals<ToJSON<bigint>, bigint> = true
+        const _tSymbol: Equals<ToJSON<symbol>, symbol> = true
+        const _tUndefined: Equals<ToJSON<undefined>, undefined> = true
+        const _tNull: Equals<ToJSON<null>, null> = true
+    })
+
+    it("Does not transform non-schema types", () => {
+        class C extends Schema {
+            time: number
+            pos: { x: number, y: number }
+        }
+        const _t1: Equals<ToJSON<C>, {
+            time: number
+            pos: { x: number, y: number }
+        }> = true
+    })
+
+    it("Primitive type on root", () => {
+        class C extends Schema {
+            @type('number') time: number
+            @type('string') name: string
+        }
+        const _t1: Equals<ToJSON<C>, {
+            time: number
+            name: string
+        }> = true
+    })
+
+    it("Schema type on root", () => {
+        class C extends Schema {
+            @type(VecSchema) ballPos: VecSchema
+        }
+        const _t1: Equals<ToJSON<C>, {
+            ballPos: {
+                x: number
+                y: number
+            }
+        }> = true
+    })
+
+    it("MapSchema on root", () => {
+        class C extends Schema {
+            @type({map: VecSchema}) positions: MapSchema<VecSchema>
+        }
+        const _t1: Equals<ToJSON<C>, {
+            positions: Record<string, {
+                x: number
+                y: number
+            }>
+        }> = true
+    })
+
+    it("ArraySchema on root", () => {
+        class C extends Schema {
+            @type({map: VecSchema}) positions: ArraySchema<VecSchema>
+        }
+        const _t1: Equals<ToJSON<C>, {
+            positions: Array<{
+                x: number
+                y: number
+            }>
+        }> = true
+    })
+})

--- a/test/src/TypeScriptTypes.test.ts
+++ b/test/src/TypeScriptTypes.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
-import { State, Player, DeepState, DeepMap, DeepChild, Position, DeepEntity } from "./Schema";
-import { Schema, ArraySchema, MapSchema, type } from "../src";
+import { State, Player, DeepState, DeepMap, DeepChild, Position, DeepEntity } from "../Schema";
+import { Schema, ArraySchema, MapSchema, type } from "../../src";
 
 describe("TypeScript Types", () => {
     it("strict null/undefined checks", () => {


### PR DESCRIPTION
Update the `ToJSON` utility type so that it recursively transforms the types of nested schemas.

`ToJSON` has a few flaws:

- If you call `.toJson()` on a schema that has a property that is _not_ mapped, the property will not be transormed by `ToJson`
```ts
export class VecSchema extends Schema {
    @type('number') x: number
    @type('number') y: number
}

class RoomSchema extends Schema {
    @type(VecSchema) pos: VecSchema
}
```

- Even if you call `.toJson()` on a schema that has a property that _is_ mapped, if the values in the map has non-primitive schemas, those will not be mapped either.
```ts
export class VecSchema extends Schema {
    @type('number') x: number
    @type('number') y: number
}

class Player extends Schema {
    @type(VecSchema) pos: VecSchema
}

class RoomSchema extends Schema {
    @type({map: Player}) pos: VecSchema
}
```