### PR TITLE
Map schema to prevent undefined reference

### DIFF
--- a/src/types/custom/MapSchema.ts
+++ b/src/types/custom/MapSchema.ts
@@ -26,10 +26,12 @@ export class MapSchema<V=any, K extends string = string> implements Map<K, V>, C
      * - Then, the encoder iterates over all "owned" properties per instance and encodes them.
      */
     static [$filter] (ref: MapSchema, index: number, view: StateView) {
+        const exists = ref[$getByIndex](index) !== undefined;
+        const existsAndChanges = exists && view.items.has(ref[$getByIndex](index)[$changes])
         return (
             !view  ||
             typeof (ref[$childType]) === "string" ||
-            view.items.has(ref[$getByIndex](index)[$changes])
+            existsAndChanges
         );
     }
 


### PR DESCRIPTION
I'm pretty sure this is a bug, but sometimes when I run the alpha of colyseus 0.16 with this version I get the error:

```
TypeError: Cannot read properties of undefined (reading 'Symbol($changes)')
    at [$filter] (/Users/lukewood/workspace/yeti/node_modules/.pnpm/@colyseus+schema@3.0.0-alpha.23/node_modules/@colyseus/schema/src/types/custom/MapSchema.ts:32:51)
    at Encoder.encode (/Users/lukewood/workspace/yeti/node_modules/.pnpm/@colyseus+schema@3.0.0-alpha.23/node_modules/@colyseus/schema/src/encoder/Encoder.ts:104:32)
    at Encoder.encodeView (/Users/lukewood/workspace/yeti/node_modules/.pnpm/@colyseus+schema@3.0.0-alpha.23/node_modules/@colyseus/schema/src/encoder/Encoder.ts:204:14)
    at SchemaSerializer.applyPatches (/Users/lukewood/workspace/yeti/node_modules/.pnpm/@colyseus+core@0.16.0-preview.31/node_modules/@colyseus/core/build/serializer/SchemaSerializer.js:93:78)
    at QuickplayRoom.broadcastPatch (/Users/lukewood/workspace/yeti/node_modules/.pnpm/@colyseus+core@0.16.0-preview.31/node_modules/@colyseus/core/build/Room.js:401:41)
    at Timeout.QuickplayRoom.handleTick [as _onTimeout] (/Users/lukewood/workspace/yeti/apps/bulletz/server/src/QuickplayRoom.ts:73:12)
    at listOnTimeout (node:internal/timers:573:17)
    at processTimers (node:internal/timers:514:7)
```

perhaps this is just a "workaround" rather than the fix of the root cause.  I don't know the new repo structure that well, but hopefully this is a fix.