### PR TITLE
fix: splice should shift remaining elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colyseus/schema",
-  "version": "2.0.33",
+  "version": "2.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colyseus/schema",
-      "version": "2.0.33",
+      "version": "2.0.36",
       "license": "MIT",
       "bin": {
         "schema-codegen": "bin/schema-codegen"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/schema",
-  "version": "2.0.35",
+  "version": "2.0.36",
   "description": "Binary state serializer with delta encoding for games",
   "bin": {
     "schema-codegen": "./bin/schema-codegen"

--- a/src/types/ArraySchema.ts
+++ b/src/types/ArraySchema.ts
@@ -340,6 +340,15 @@ export class ArraySchema<V = any> implements Array<V>, SchemaDecoderCallbacks {
             this.$deleteAt(indexes[i]);
         }
 
+        const shiftAmount = items.length - deleteCount;
+        if (shiftAmount > 0) {
+            for (let i = indexes.length - 1; i >= start + deleteCount; i--) {
+                const currentIndex = indexes[i];
+                const newIndex = currentIndex + shiftAmount;
+                this.setAt(newIndex, this.$items.get(currentIndex));
+            }
+        }
+
         for (let i = 0; i < items.length; i++) {
             this.setAt(start + i, items[i]);
         }
@@ -395,6 +404,7 @@ export class ArraySchema<V = any> implements Array<V>, SchemaDecoderCallbacks {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
+    // @ts-ignore
     every(callbackfn: (value: V, index: number, array: V[]) => unknown, thisArg?: any): boolean {
         return Array.from(this.$items.values()).every(callbackfn, thisArg);
     }

--- a/test/ArraySchema.test.ts
+++ b/test/ArraySchema.test.ts
@@ -520,6 +520,24 @@ describe("ArraySchema Tests", () => {
         assert.strictEqual(decodedState.arrayOfPlayers[1].name, "Katarina Lyons");
     })
 
+    it("should correctly shift elements when inserting more items than removed", () => {
+        const state = new State();
+        const p1 = new Player("Jake");
+        const p2 = new Player("Snake");
+        const p3 = new Player("Cyberhawk");
+
+        state.arrayOfPlayers = new ArraySchema(p1, p2);
+        state.arrayOfPlayers.splice(1, 0, p3);
+
+        const decodedState = new State();
+        decodedState.decode(state.encode());
+
+        assert.strictEqual(decodedState.arrayOfPlayers.length, 3);
+        assert.strictEqual(decodedState.arrayOfPlayers[0].name, "Jake");
+        assert.strictEqual(decodedState.arrayOfPlayers[1].name, "Cyberhawk");
+        assert.strictEqual(decodedState.arrayOfPlayers[2].name, "Snake");
+    });
+
     it("should adjust the indexes of the elements after a splice", () => {
         const state = new State();
         const p1 = new Player("Jake")


### PR DESCRIPTION
The `splice` method was not correctly handling the insertion of new elements, especially when the number of inserted elements differed from the number of deleted elements. 

I add shift to the remaining elements in this PR so it will work properly.

@endel  Hi, could u have a look on this ?