### PR TITLE
Fixed type definition in ArraySchema

### DIFF
--- a/src/types/ArraySchema.ts
+++ b/src/types/ArraySchema.ts
@@ -88,7 +88,7 @@ export class ArraySchema<V = any> implements Array<V>, SchemaDecoderCallbacks {
 
     protected $refId: number = 0;
 
-    [n: number]: V;
+    [n: number]: V | undefined;
 
     //
     // Decoding callbacks
@@ -163,7 +163,7 @@ export class ArraySchema<V = any> implements Array<V>, SchemaDecoderCallbacks {
         return value;
     }
 
-    at(index: number) {
+    at(index: number): V | undefined {
         //
         // FIXME: this should be O(1)
         //


### PR DESCRIPTION
The returned value from ArraySchema can be undefined if no entry exists at the specified index