### PR TITLE
feat: Encoding enhancements

### DIFF
--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -25,7 +25,16 @@ export type RawPrimitiveType = "string" |
     "int64" |
     "uint64" |
     "float32" |
-    "float64";
+    "float64" |
+    "cstring" |
+    "bigInt64" |
+    "bigUint64" |
+    "varUint" |
+    "varInt" |
+    "varBigUint" |
+    "varBigInt" |
+    "varFloat32" |
+    "varFloat64";
 
 export type PrimitiveType = RawPrimitiveType | typeof Schema | object;
 

--- a/src/codegen/languages/js.ts
+++ b/src/codegen/languages/js.ts
@@ -15,6 +15,15 @@ const typeMaps = {
     "uint64": "number",
     "float32": "number",
     "float64": "number",
+    "cstring": "string",
+    "bigInt64": "bigint",
+    "bigUint64": "bigint",
+    "varUint": "number",
+    "varInt": "number",
+    "varBigUint": "bigint",
+    "varBigInt": "bigint",
+    "varFloat32": "number",
+    "varFloat64": "number",
 }
 
 const distinct = (value, index, self) => self.indexOf(value) === index;

--- a/src/codegen/languages/ts.ts
+++ b/src/codegen/languages/ts.ts
@@ -15,6 +15,15 @@ const typeMaps = {
     "uint64": "number",
     "float32": "number",
     "float64": "number",
+    "cstring": "string",
+    "bigInt64": "bigint",
+    "bigUint64": "bigint",
+    "varUint": "number",
+    "varInt": "number",
+    "varBigUint": "bigint",
+    "varBigInt": "bigint",
+    "varFloat32": "number",
+    "varFloat64": "number",
 }
 
 const distinct = (value, index, self) => self.indexOf(value) === index;

--- a/src/encoding/assert.ts
+++ b/src/encoding/assert.ts
@@ -23,11 +23,22 @@ export function assertType(value: any, type: string, klass: Schema, field: strin
         case "uint64":
         case "float32":
         case "float64":
+        case "varUint":
+        case "varInt":
+        case "varFloat32":
+        case "varFloat64":
             typeofTarget = "number";
             if (isNaN(value)) {
                 console.log(`trying to encode "NaN" in ${klass.constructor.name}#${field}`);
             }
             break;
+        case "bigInt64":
+        case "bigUint64":
+        case "varBigUint":
+        case "varBigInt":
+            typeofTarget = "bigint";
+            break;
+        case "cstring":
         case "string":
             typeofTarget = "string";
             allowNull = true;

--- a/src/encoding/decode.ts
+++ b/src/encoding/decode.ts
@@ -38,7 +38,7 @@ const _int32 = new Int32Array(_convoBuffer);
 const _int64 = new BigInt64Array(_convoBuffer);
 const _float32 = new Float32Array(_convoBuffer);
 const _float64 = new Float64Array(_convoBuffer);
-const _decoder = new TextDecoder();
+const _decoder = typeof TextDecoder === "function" ? new TextDecoder() : undefined;
 
 /**
  * msgpack implementation highly based on notepack.io
@@ -219,6 +219,7 @@ export function string(bytes: BufferLike, it: Iterator) {
 }
 
 export function cstring(bytes: BufferLike, it: Iterator) {
+  if(!_decoder) throw "Decoder (type 'cstring') Error: globalThis.TextDecoder is not available on this platform, apply a polyfill or use the 'string' primitive encoding instead!";
   // should short circuit if buffer length can't be determined for some reason so we don't just infinitely loop
   const len = (bytes as Buffer | ArrayBuffer).byteLength ?? (bytes as number[]).length;
   if (len === undefined) throw TypeError("Unable to determine length of 'BufferLike' " + bytes.toString());

--- a/src/encoding/encode.ts
+++ b/src/encoding/encode.ts
@@ -215,12 +215,12 @@ export function number(bytes: BufferLike, value: number, it: Iterator) {
     return number(bytes, (value > 0) ? Number.MAX_SAFE_INTEGER : -Number.MAX_SAFE_INTEGER, it);
 
   } else if (value !== (value|0)) {
-    if (Math.abs(value) < 3.4028235e+38) { // range check
+    if (Math.abs(value) <= 3.4028235e+38) { // range check
         _float32[0] = value;
-        if (Math.abs(_float32[0] - v) < 1e-4) { // precision check; adjust 1e-n (n = precision) to in-/decrease acceptable precision loss
+        if (Math.abs(Math.abs(_float32[0]) - Math.abs(value)) < 1e-4) { // precision check; adjust 1e-n (n = precision) to in-/decrease acceptable precision loss
             // now we know value is in range for f32 and has acceptable precision for f32
             bytes[it.offset++] = 0xca;
-            writeFloat32(bytes, value);
+            writeFloat32(bytes, value, it);
             return 5;
         }
     }

--- a/src/encoding/encode.ts
+++ b/src/encoding/encode.ts
@@ -215,17 +215,19 @@ export function number(bytes: BufferLike, value: number, it: Iterator) {
     return number(bytes, (value > 0) ? Number.MAX_SAFE_INTEGER : -Number.MAX_SAFE_INTEGER, it);
 
   } else if (value !== (value|0)) {
+    if (Math.abs(value) < 3.4028235e+38) { // range check
+        _float32[0] = value;
+        if (Math.abs(_float32[0] - v) < 1e-4) { // precision check; adjust 1e-n (n = precision) to in-/decrease acceptable precision loss
+            // now we know value is in range for f32 and has acceptable precision for f32
+            bytes[it.offset++] = 0xca;
+            writeFloat32(bytes, value);
+            return 5;
+        }
+    }
+      
     bytes[it.offset++] = 0xcb;
     writeFloat64(bytes, value, it);
     return 9;
-
-    // TODO: encode float 32?
-    // is it possible to differentiate between float32 / float64 here?
-
-    // // float 32
-    // bytes.push(0xca);
-    // writeFloat32(bytes, value);
-    // return 5;
   }
 
   if (value >= 0) {

--- a/src/encoding/encode.ts
+++ b/src/encoding/encode.ts
@@ -289,13 +289,11 @@ export function cstring(bytes: BufferLike, value: string = "", it: Iterator) {
 }
 
 export function number(bytes: BufferLike, value: number, it: Iterator) {
-  if (isNaN(value)) {
-    return number(bytes, 0, it);
-
-  } else if (!isFinite(value)) {
-    return number(bytes, (value > 0) ? Number.MAX_SAFE_INTEGER : -Number.MAX_SAFE_INTEGER, it);
-
-  } else if (value !== (value|0)) {
+  if (isNaN(value) || !isFinite(value) {
+    bytes[it.offset++] = 0xcb;
+    float64(bytes, value, it);
+    return 9;
+  } else if (value !== (value | 0)) {
     if (Math.abs(value) <= 3.4028235e+38) { // range check
         _float32[0] = value;
         if (Math.abs(Math.abs(_float32[0]) - Math.abs(value)) < 1e-4) { // precision check; adjust 1e-n (n = precision) to in-/decrease acceptable precision loss

--- a/src/encoding/encode.ts
+++ b/src/encoding/encode.ts
@@ -44,7 +44,7 @@ const _int32 = new Int32Array(_convoBuffer);
 const _int64 = new BigInt64Array(_convoBuffer);
 const _float32 = new Float32Array(_convoBuffer);
 const _float64 = new Float64Array(_convoBuffer);
-const _encoder = new TextEncoder();
+const _encoder = typeof TextEncoder === "function" ? new TextEncoder() : undefined;
 
 const hasBufferByteLength = (typeof Buffer !== 'undefined' && Buffer.byteLength);
 
@@ -276,6 +276,7 @@ export function string(bytes: BufferLike, value: string, it: Iterator) {
 }
 
 export function cstring(bytes: BufferLike, value: string = "", it: Iterator) {
+  if(!_encoder) throw "Encoder Error: globalThis.TextEncoder is not available on this platform, apply a polyfill or use the 'string' primitive encoding instead";
   value ??= "";
   value += "\x00";
   if(bytes instanceof Uint8Array) {

--- a/src/encoding/encode.ts
+++ b/src/encoding/encode.ts
@@ -276,7 +276,7 @@ export function string(bytes: BufferLike, value: string, it: Iterator) {
 }
 
 export function cstring(bytes: BufferLike, value: string = "", it: Iterator) {
-  if(!_encoder) throw "Encoder Error: globalThis.TextEncoder is not available on this platform, apply a polyfill or use the 'string' primitive encoding instead";
+  if(!_encoder) throw "Encoder (type 'cstring') Error: globalThis.TextEncoder is not available on this platform, apply a polyfill or use the 'string' primitive encoding instead";
   value ??= "";
   value += "\x00";
   if(bytes instanceof Uint8Array) {

--- a/src/types/HelperTypes.ts
+++ b/src/types/HelperTypes.ts
@@ -27,6 +27,15 @@ export type InferValueType<T extends DefinitionType> =
     : T extends "float32" ? number
     : T extends "float64" ? number
     : T extends "boolean" ? boolean
+    : T extends "cstring" ? string
+    : T extends "bigInt64" ? bigint
+    : T extends "bigUint64" ? bigint
+    : T extends "varUint" ? number
+    : T extends "varInt" ? number
+    : T extends "varBigUint" ? bigint
+    : T extends "varBigInt" ? bigint
+    : T extends "varFloat32" ? number
+    : T extends "varFloat64" ? number
 
     : T extends { type: infer ChildType extends Constructor } ? InstanceType<ChildType>
     : T extends { type: infer ChildType extends PrimitiveType } ? ChildType

--- a/test/Schema.test.ts
+++ b/test/Schema.test.ts
@@ -140,11 +140,11 @@ describe("Type: Schema", () => {
             }
 
             let data = new Data();
-            data.int64 = -9223372036854775808;
+            data.int64 = Number.MIN_SAFE_INTEGER;
 
             const decoded = new Data();
             decoded.decode(data.encode());
-            assert.strictEqual(decoded.int64, -9223372036854775808);
+            assert.strictEqual(decoded.int64, Number.MIN_SAFE_INTEGER);
         });
 
         it("float32", () => {
@@ -156,6 +156,7 @@ describe("Type: Schema", () => {
             data.float32 = 24.5;
 
             let encoded = data.encode();
+
             // assert.deepEqual(encoded, [0, 0, 0, 196, 65]);
 
             const decoded = new Data();
@@ -187,9 +188,9 @@ describe("Type: Schema", () => {
                 @type("number") varint_uint16 = 65535;
                 @type("number") varint_int32 = -2147483648;
                 @type("number") varint_uint32 = 4294967295;
-                @type("number") varint_int64 = -9223372036854775808;
+                @type("number") varint_int64 = Number.MIN_SAFE_INTEGER;
                 @type("number") varint_uint64 = Number.MAX_SAFE_INTEGER; // 9007199254740991
-                @type("number") varint_float32 = -3.40282347e+38;
+                @type("number") varint_float32 = -3.4028235e+38;
                 @type("number") varint_float64 = 1.7976931348623157e+308;
             }
 
@@ -206,9 +207,9 @@ describe("Type: Schema", () => {
             assert.strictEqual(decoded.varint_uint16, 65535);
             assert.strictEqual(decoded.varint_int32, -2147483648);
             assert.strictEqual(decoded.varint_uint32, 4294967295);
-            assert.strictEqual(decoded.varint_int64, -9223372036854775808);
+            assert.strictEqual(decoded.varint_int64, Number.MIN_SAFE_INTEGER);
             assert.strictEqual(decoded.varint_uint64, Number.MAX_SAFE_INTEGER);
-            assert.strictEqual(decoded.varint_float32, -3.40282347e+38);
+            assert.strictEqual(decoded.varint_float32.toPrecision(5), "-3.4028e+38"); // adjust precision according to encoder check (max 8)
             assert.strictEqual(decoded.varint_float64, 1.7976931348623157e+308);
 
             const badByteIndex = encoded.findIndex((byte) => byte < 0 || byte > 255);

--- a/test/Schema.test.ts
+++ b/test/Schema.test.ts
@@ -179,6 +179,74 @@ describe("Type: Schema", () => {
             assert.strictEqual(decoded.float64, 24.5);
         });
 
+        it("cstring", () => {
+            class Data extends Schema {
+                @type("cstring") string: string;
+            }
+
+            let data = new Data();
+            data.string = "test12345";
+
+            let encoded = data.encode();
+
+            const decoded = new Data();
+            decoded.decode(encoded);
+            assert.strictEqual(decoded.string, "test12345");
+        });
+
+        it("bigints", () => {
+            class Data extends Schema {
+                @type("bigUint64") u64: bigint;
+                @type("bigInt64") i64: bigint;
+            }
+
+            const buint = BigInt(Number.MAX_SAFE_INTEGER) + 10000n;
+            const bint = BigInt(Number.MIN_SAFE_INTEGER) - 10000n;
+
+            let data = new Data();
+            data.u64 = buint;
+            data.i64 = bint;
+
+            let encoded = data.encode();
+
+            const decoded = new Data();
+            decoded.decode(encoded);
+
+            assert.strictEqual(decoded.u64, buint);
+            assert.strictEqual(decoded.i64, bint);
+        });
+
+        it("leb128", () => {
+            class Data extends Schema {
+                @type("varUint") vu: number;
+                @type("varInt") vi: number;
+                @type("varBigUint") vbu: bigint;
+                @type("varBigInt") vbi: bigint;
+                @type("varFloat32") vf32: number;
+                @type("varFloat64") vf64: number;
+            }
+
+            let data = new Data();
+            data.vu = 2 ** 30;
+            data.vi = -(2 ** 30);
+            data.vbu = 0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFFn; // 128 bit
+            data.vbi = -0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFFn;
+            data.vf32 = -5.3235;
+            data.vf64 = 1.7976931348623157e+308;
+
+            let encoded = data.encode();
+
+            const decoded = new Data();
+            decoded.decode(encoded);
+
+            assert.strictEqual(decoded.vu, 2 ** 30);
+            assert.strictEqual(decoded.vi, -(2 ** 30));
+            assert.strictEqual(decoded.vbu, 0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFFn);
+            assert.strictEqual(decoded.vbi, -0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFFn);
+            assert.strictEqual(decoded.vf32.toPrecision(5), "-5.3235");
+            assert.strictEqual(decoded.vf64, 1.7976931348623157e+308);
+        });
+
         it("varint", () => {
             class Data extends Schema {
                 @type("number") varint_minus1 = -1;


### PR DESCRIPTION
List of changes:
- Adds support for float32 type encoding within the "number" (vlq) encoder with a default precision tolerance of 4 decimal digits
- Adds the "cstring" (null terminated c-like utf-8 string) encoding to support for small bandwidth optimizations in regards to sending long strings
- Adds actual (not just 52 bit values like with js builtin numbers) 64-bit bigint encoding types "bigInt64" / "bigUint64" which rely on the builtin bigint type
- Adds leb128 based var length int encoding types (varUint / varInt) as well as their bigint counterparts (varBigUint, varBigInt)
- Adds leb128 based var length float encoding parts (varFloat32, varFloat64), these allow bandwidth optimization benefits for some numbers

Codegen:
- Adds codegen functionality (only js/ts for now) for new types

Tests:
- Adds tests for new encoding types
- Fixed tests regarding existing "int64" / "uint64" types since they were exceeding the 52 bit cap for js numbers
