### PR TITLE
Fix onChange return type in StateCallbacks.ts

### DIFF
--- a/src/decoder/strategy/StateCallbacks.ts
+++ b/src/decoder/strategy/StateCallbacks.ts
@@ -94,7 +94,7 @@ export type CollectionCallback<K, V> = {
      * If you want to listen to changes on individual items, you need to attach callbacks to the them directly inside the `onAdd` callback.
      *
      * @param callback
-     * @return callback to detach the onRemove listener
+     * @return callback to detach the onChange listener
      */
     onChange(callback: (item: V, index: K) => void): () => void;
 };


### PR DESCRIPTION
Seemes as if the Collection callbacks proxy .onChange() returns a cleanup hook, but the typings hide that fact.