### PR TITLE
 Fix fake change callbacks for collection fields

### DIFF
--- a/src/decoder/DecodeOperation.ts
+++ b/src/decoder/DecodeOperation.ts
@@ -183,7 +183,9 @@ export const decodeSchemaOperation: DecodeOperation = function <T extends Schema
     }
 
     // add change
-    if (previousValue !== value) {
+    if (previousValue !== value && (typeof value !== 'object' ||
+            typeof previousValue !== 'object' ||
+            decoder.root.refIds.get(previousValue) !== decoder.root.refIds.get(value))){
         allChanges.push({
             ref,
             refId: decoder.currentRefId,


### PR DESCRIPTION

Problem: The .listen() callback fires for collection fields (ArraySchema/MapSchema) even when other fields change. 

Impact: Both cases trigger the field-level change callback with different proxy references (previousValue !== value is always true), causing false positives. Libraries that monitor state changes (like colyseus-events) receive duplicate events or cannot detect actual field replacements.

Solution: Improve change detection to check refIds for collection types before firing field-level callbacks. Only emit when the container instance itself changes
