### PR TITLE
Fix the issue where Symbol.metadata cannot be assigned.

### DIFF
--- a/src/Metadata.ts
+++ b/src/Metadata.ts
@@ -294,7 +294,11 @@ export const Metadata = {
             }
         }
 
-        constructor[Symbol.metadata] = metadata;
+        Object.defineProperty(constructor, Symbol.metadata, {
+            value: metadata,
+            writable: false,
+            configurable: true
+        });
 
         return metadata;
     },


### PR DESCRIPTION
In the latest basic library of WeChatMiniGame, an exception will be reported as "Cannot assign to read only property 'Symbol(symbol.metadata)' of function..."