### PR TITLE
fix: encode StateView changes during full view snapshots

### DIFF
--- a/src/encoder/Encoder.ts
+++ b/src/encoder/Encoder.ts
@@ -173,6 +173,8 @@ export class Encoder<T extends Schema = any> {
     ) {
         const viewOffset = it.offset;
 
+        this.encodeViewChanges(view, it, bytes);
+
         // try to encode "filtered" changes
         this.encode(it, view, bytes, "allFilteredChanges", true, viewOffset);
 
@@ -190,6 +192,22 @@ export class Encoder<T extends Schema = any> {
     ) {
         const viewOffset = it.offset;
 
+        this.encodeViewChanges(view, it, bytes);
+
+        // try to encode "filtered" changes
+        this.encode(it, view, bytes, "filteredChanges", false, viewOffset);
+
+        return concatBytes(
+            bytes.subarray(0, sharedOffset),
+            bytes.subarray(viewOffset, it.offset)
+        );
+    }
+
+    protected encodeViewChanges(
+        view: StateView,
+        it: Iterator,
+        bytes: Uint8Array = this.sharedBuffer
+    ) {
         //
         // Iterate `view.changes` in topological order so a refId is never
         // SWITCH_TO_STRUCTURE'd before an earlier op has introduced it on
@@ -219,18 +237,25 @@ export class Encoder<T extends Schema = any> {
                 continue;
             }
 
-            const keys = Object.keys(changes);
-            if (keys.length === 0) {
-                // FIXME: avoid having empty changes if no changes were made
-                // console.log("changes.size === 0, skip", refId, changeTree.ref.constructor.name);
-                continue;
-            }
-
             const ref = changeTree.ref;
-
             const ctor = ref.constructor;
             const encoder = ctor[$encoder];
             const metadata = ctor[Symbol.metadata];
+            const keys = Object.keys(changes).filter((index) => {
+                if (metadata && metadata[Number(index)] === undefined) {
+                    delete changes[Number(index)];
+                    return false;
+                }
+
+                return true;
+            });
+
+            if (keys.length === 0) {
+                // FIXME: avoid having empty changes if no changes were made
+                // console.log("changes.size === 0, skip", refId, changeTree.ref.constructor.name);
+                view.changes.delete(refId);
+                continue;
+            }
 
             bytes[it.offset++] = SWITCH_TO_STRUCTURE & 255;
             encode.number(bytes, ref[$refId], it);
@@ -254,14 +279,6 @@ export class Encoder<T extends Schema = any> {
         // clear "view" changes after encoding
         view.changes.clear();
         view.changesOutOfOrder = false;
-
-        // try to encode "filtered" changes
-        this.encode(it, view, bytes, "filteredChanges", false, viewOffset);
-
-        return concatBytes(
-            bytes.subarray(0, sharedOffset),
-            bytes.subarray(viewOffset, it.offset)
-        );
     }
 
     /**

--- a/test/StateView.test.ts
+++ b/test/StateView.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as util from "util";
-import { Schema, type, view, ArraySchema, MapSchema, StateView, Encoder, ChangeTree, $changes, OPERATION, SetSchema, CollectionSchema } from "../src";
+import { Schema, type, view, ArraySchema, MapSchema, StateView, Encoder, ChangeTree, $changes, $refId, OPERATION, SetSchema, CollectionSchema } from "../src";
 import { createClientWithView, encodeMultiple, assertEncodeAllMultiple, getDecoder, getEncoder, createInstanceFromReflection, encodeAllForView, encodeAllMultiple, assertRefIdCounts, InheritanceRoot, Position } from "./Schema";
 import { nanoid } from "nanoid";
 
@@ -28,6 +28,70 @@ describe("StateView", () => {
         assert.strictEqual(client2.state.prop2, undefined);
 
         assertEncodeAllMultiple(encoder, state, [client1, client2])
+    });
+
+    it("should encode pending view additions during encodeAllView snapshots", () => {
+        const VIEW_TAG = 1;
+
+        class Entity extends Schema {
+            @view(VIEW_TAG) @type("string") id: string = "";
+            @view(VIEW_TAG) @type("uint16") itemId: number = 0;
+        }
+
+        class State extends Schema {
+            @view(VIEW_TAG) @type({ map: Entity }) entities = new MapSchema<Entity>();
+        }
+
+        const state = new State();
+        const encoder = getEncoder(state);
+        const entity = new Entity().assign({ id: "drop-1", itemId: 2 });
+
+        state.entities.set(entity.id, entity);
+        encoder.discardChanges();
+
+        // Simulate a full-state snapshot whose filtered baseline no longer
+        // carries the original ADDs. The pending StateView.add() changes must
+        // still be enough to introduce the entity and its tagged fields.
+        for (const ref of [state, state.entities, entity]) {
+            const allFilteredChanges = ref[$changes]?.allFilteredChanges;
+            if (allFilteredChanges) {
+                allFilteredChanges.operations = [];
+                allFilteredChanges.indexes = {};
+            }
+        }
+
+        const client = createClientWithView(state);
+        client.view.add(entity, VIEW_TAG);
+
+        encodeAllForView(encoder, client);
+
+        assert.strictEqual(client.state.entities.get("drop-1")?.itemId, 2);
+    });
+
+    it("should skip stale invalid StateView field changes", () => {
+        class Player extends Schema {
+            @view() @type("string") name: string = "Player";
+        }
+
+        class State extends Schema {
+            @view() @type({ map: Player }) players = new MapSchema<Player>();
+        }
+
+        const state = new State();
+        const encoder = getEncoder(state);
+        const player = new Player();
+        state.players.set("one", player);
+
+        const client = createClientWithView(state);
+        client.view.add(player);
+        encodeMultiple(encoder, state, [client]);
+
+        const playerRefId = player[$refId];
+        client.view.changes.set(playerRefId, { 999: OPERATION.ADD });
+        client.view.changes.set(999999, { 0: OPERATION.ADD });
+
+        assert.doesNotThrow(() => encodeMultiple(encoder, state, [client]));
+        assert.strictEqual(client.view.changes.size, 0);
     });
 
     it("should not be required to add parent structure", () => {


### PR DESCRIPTION
## Summary

Follow-up to:

- colyseus/colyseus#936
- colyseus/colyseus#935
- `@colyseus/schema@4.0.22` / commit `091f314`

This is a follow-up to the `StateView` refId ordering work released in `4.0.22`.

`Encoder.encodeAllView()` currently only appends `allFilteredChanges` to the shared full-state bytes. If a view has pending manual `StateView.add()` changes, those changes are ignored during full view snapshots, even though `encodeView()` consumes them during patch encoding.

This patch:

- factors pending `view.changes` encoding out of `encodeView()` into a shared `encodeViewChanges()` helper
- calls that helper from both `encodeView()` and `encodeAllView()`
- skips stale invalid `view.changes` entries for detached refs or invalid schema field indexes before writing `SWITCH_TO_STRUCTURE`
