### PR TITLE
fix: align MapSchema iterator with native Map

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && rollup -c rollup.config.mjs",
     "watch": "tsc -p tsconfig.build.json -w",
-    "test": "tsx --tsconfig tsconfig.test.json ./node_modules/.bin/mocha test/*.test.ts test/**/*.test.ts",
+    "test": "npm run test:types && tsx --tsconfig tsconfig.test.json ./node_modules/.bin/mocha test/*.test.ts test/**/*.test.ts",
+    "test:types": "tsc -p tsconfig.build.json && tsc -p tsconfig.types.json",
     "typecheck": "tsc -p tsconfig.test.json",
     "coverage": "c8 npm run test",
     "generate-test-1": "bin/schema-codegen test-external/PrimitiveTypes.ts --namespace SchemaTest.PrimitiveTypes --output ../colyseus-unity-sdk/Assets/Colyseus/Tests/Editor/ColyseusTests/Schema/PrimitiveTypes",

--- a/src/types/custom/MapSchema.ts
+++ b/src/types/custom/MapSchema.ts
@@ -77,7 +77,7 @@ export class MapSchema<V=any, K extends string = string> implements Map<K, V>, C
     }
 
     /** Iterator */
-    [Symbol.iterator](): IterableIterator<[K, V]> { return this.$items[Symbol.iterator](); }
+    [Symbol.iterator](): ReturnType<Map<K, V>[typeof Symbol.iterator]> { return this.$items[Symbol.iterator](); }
     get [Symbol.toStringTag]() { return this.$items[Symbol.toStringTag] }
 
     static get [Symbol.species]() { return MapSchema; }

--- a/test/MapSchemaIterator.types.ts
+++ b/test/MapSchemaIterator.types.ts
@@ -1,0 +1,8 @@
+import { MapSchema } from "../build/index.js";
+
+const schema = new MapSchema<number>();
+const map: Map<string, number> = schema;
+const iterator: ReturnType<Map<string, number>[typeof Symbol.iterator]> = schema[Symbol.iterator]();
+
+void map;
+void iterator;

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -15,6 +15,7 @@
   ],
   "exclude": [
     "build",
+    "test/**/*.types.ts",
     "test/ChangeAPI._test.ts"
   ]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": false,
+    "noEmit": true,
+    "types": []
+  },
+  "files": ["test/MapSchemaIterator.types.ts"]
+}


### PR DESCRIPTION
## Summary

- derive `MapSchema[Symbol.iterator]` from the native `Map<K, V>` contract
- add a strict NodeNext declaration regression with `skipLibCheck: false`
- keep the declaration fixture isolated from the ordinary source/test typecheck

## Why

TypeScript 5.9 models `Map[Symbol.iterator]()` as `MapIterator`, which includes modern iterator/disposable members. The explicit `IterableIterator` annotation is narrower, so strict consumers receive TS2416 when `MapSchema` implements `Map`. Using `ReturnType<Map<K, V>[typeof Symbol.iterator]>` follows the consumer compiler's standard library without naming version-specific iterator types and does not change runtime behavior.

## Verification

- `npm run test:types`
- `npm run typecheck`
- 29 non-codegen Mocha test files pass on Windows; the unchanged codegen subprocess suite has 9 pre-existing Windows path failures
- fresh `npm pack` install compiles with TypeScript 5.9.3, strict NodeNext, and `skipLibCheck: false`
- packed runtime import and `MapSchema` construction pass
- TypeScript 5.0.4 accepts the new source annotation and the candidate adds no diagnostics versus the current generated-declaration baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)