### PR TITLE
Encoder: drop per-tick `invisible` WeakSet churn from view-filtered encode

### DIFF
--- a/src/encoder/Encoder.ts
+++ b/src/encoder/Encoder.ts
@@ -67,13 +67,8 @@ export class Encoder<T extends Schema = any> {
         while (current = current.next) {
             const changeTree = (current as ChangeTreeNode).changeTree;
 
-            if (hasView) {
-                if (!view.isChangeTreeVisible(changeTree)) {
-                    // console.log("MARK AS INVISIBLE:", { ref: changeTree.ref.constructor.name, refId: changeTree.ref[$refId], raw: changeTree.ref.toJSON() });
-                    view.invisible.add(changeTree);
-                    continue; // skip this change tree
-                }
-                view.invisible.delete(changeTree); // remove from invisible list
+            if (hasView && !view.isChangeTreeVisible(changeTree)) {
+                continue; // skip this change tree
             }
 
             const changeSet = changeTree[changeSetName];

--- a/src/encoder/StateView.ts
+++ b/src/encoder/StateView.ts
@@ -103,6 +103,8 @@ export class StateView {
 
         // FIXME: ArraySchema/MapSchema do not have metadata
         const metadata: Metadata = (obj.constructor as typeof Schema)[Symbol.metadata];
+        // captured before the add() below: a not-yet-visible tree is one the client lacks
+        const wasVisible = this.visible.has(changeTree);
         this.visible.add(changeTree);
 
         // add to iterable list (only the explicitly added items)
@@ -171,7 +173,7 @@ export class StateView {
                 ? changeTree.allFilteredChanges
                 : changeTree.allChanges;
 
-            const isInvisible = this.invisible.has(changeTree);
+            const isInvisible = !wasVisible;
 
             for (let i = 0, len = changeSet.operations.length; i < len; i++) {
                 const index = changeSet.operations[i];


### PR DESCRIPTION
## Motivation

A production game we run is CPU-limited on concurrent players by per-view state encoding — the encode step scales with client count and becomes the wall well before the network or simulation does. A CPU profile of the encoder under a dense, view-filtered room pointed at a single, removable cost.

## The finding

In `Encoder.encode()`, for **every** `StateView` we walk the whole list of world-changed `ChangeTree`s and, for each tree **not** visible to that view, re-add it to the view's `invisible` `WeakSet` — every tick:

```ts
if (hasView) {
    if (!view.isChangeTreeVisible(changeTree)) {
        view.invisible.add(changeTree);   // re-added every tick, for every invisible changed tree
        continue;
    }
    view.invisible.delete(changeTree);    // and deleted every tick, for every visible one
}
```

That's `O(views × world-changed-trees)` WeakSet writes per patch. In a room where, say, 300 entities change each tick and each of 300 clients sees ~60 of them, it's ~72k `invisible.add` calls/tick — for trees that were already in the set last tick. In a CPU profile it was ~35% of encode samples (`WeakCollectionSet` / `WeakMapLookupHashIndex` / `WeakCollectionDelete`).

`invisible` is read in exactly one place — `StateView.add()`, to decide whether a newly-added tree needs its **full** state sent (the client doesn't have it yet). That's equivalent to *"the tree was not already visible to this view"*, which we can read from `visible` right before the eager `visible.add()` in `add()`. So this PR derives it from `visible` and stops populating `invisible` in the hot loop.

## Change

Minimal (2 files, +5/-8):
- `Encoder.encode()`: skip trees not visible to the view; no longer touch `invisible`.
- `StateView.add()`: capture `wasVisible = this.visible.has(changeTree)` before the eager `visible.add()`, and use `!wasVisible` where `this.invisible.has(changeTree)` was read.

`StateView.invisible` is now unpopulated. I left the public field declared to avoid an API change here — it can be removed in a follow-up.

## Benchmark

Per-view encode, mirroring the shape of a dense filtered room: N players in a `@view()`-filtered `MapSchema`, M `StateView`s each `add()`-ing 60 neighbors, 3 of 6 `float32`/`uint32` fields mutated per tick, `encodeView` per view + `discardChanges` (the `SchemaSerializer.applyPatches` filtered path). Mean ms/tick over 150 ticks after warmup:

| clients (N=M) | before | after | |
|---:|---:|---:|:--|
| 150 | 2.08 ms | 1.89 ms | 9% faster |
| 300 | 6.88 ms | 5.69 ms | 17% faster |
| 450 | 16.2 ms | 10.1 ms | **38% faster** |

The improvement grows with client count because the removed cost was quadratic in it.

## Tests

Full suite passes — `450 passing` (13 pending), unchanged from `master`.