### PR TITLE
perf: avoid rescanning predecessors on removal

### DIFF
--- a/src/encoder/Root.ts
+++ b/src/encoder/Root.ts
@@ -215,17 +215,11 @@ export class Root {
         return node;
     }
 
-    protected updatePositionsAfterRemoval(list: ChangeTreeList, removedPosition: number) {
-        // Update positions for all nodes after the removed position
-        let current = list.next;
-        let position = 0;
-
+    protected updatePositionsAfterRemoval(current: ChangeTreeNode | undefined) {
+        // Predecessors retain their positions; only successors shift after an unlink.
         while (current) {
-            if (position >= removedPosition) {
-                current.position = position;
-            }
+            current.position--;
             current = current.next;
-            position++;
         }
     }
 
@@ -246,7 +240,7 @@ export class Root {
         const node = changeTree[changeSetName].queueRootNode;
 
         if (node && node.changeTree === changeTree) {
-            const removedPosition = node.position;
+            const nextNode = node.next;
 
             // Remove the node from the linked list
             if (node.prev) {
@@ -262,7 +256,7 @@ export class Root {
             }
 
             // Update positions for nodes that came after the removed node
-            this.updatePositionsAfterRemoval(changeSet, removedPosition);
+            this.updatePositionsAfterRemoval(nextNode);
 
             // Clear ChangeTree reference
             changeTree[changeSetName].queueRootNode = undefined;

--- a/test/Root.test.ts
+++ b/test/Root.test.ts
@@ -1,0 +1,68 @@
+import * as assert from "assert";
+
+import { $changes, Encoder, MapSchema, Reflection, Schema, type } from "../src";
+
+describe("Encoder Root", () => {
+    it("does not revisit predecessors when removing a nested schema", () => {
+        class Leaf extends Schema {
+            @type("number") value = 0;
+        }
+
+        class Branch extends Schema {
+            @type({ map: Leaf }) children = new MapSchema<Leaf>();
+        }
+
+        class State extends Schema {
+            @type({ map: Leaf }) noise = new MapSchema<Leaf>();
+            @type({ map: Branch }) actors = new MapSchema<Branch>();
+            @type({ map: Leaf }) trailing = new MapSchema<Leaf>();
+        }
+
+        const state = new State();
+        for (let index = 0; index < 32; index++) {
+            state.noise.set(`noise-${index}`, new Leaf().assign({ value: index }));
+        }
+
+        const actor = new Branch();
+        for (let index = 0; index < 5; index++) {
+            actor.children.set(`child-${index}`, new Leaf().assign({ value: index }));
+        }
+        state.actors.set("departing", actor);
+
+        const trailing = new Leaf().assign({ value: 1 });
+        state.trailing.set("sentinel", trailing);
+
+        const encoder = new Encoder(state);
+        const decoder = Reflection.decode<State>(Reflection.encode(encoder));
+        decoder.decode(encoder.encodeAll());
+        encoder.discardChanges();
+
+        const predecessorNode = state.noise.get("noise-0")[$changes].allChanges.queueRootNode!;
+        const trailingNode = trailing[$changes].allChanges.queueRootNode!;
+        const trailingPosition = trailingNode.position;
+        const removedNodeCount = 2 + actor.children.size;
+
+        let predecessorReads = 0;
+        let predecessorNext = predecessorNode.next;
+        Object.defineProperty(predecessorNode, "next", {
+            configurable: true,
+            get() {
+                predecessorReads++;
+                return predecessorNext;
+            },
+            set(value: typeof predecessorNext) {
+                predecessorNext = value;
+            },
+        });
+
+        state.actors.delete("departing");
+
+        assert.strictEqual(predecessorReads, 0);
+        assert.strictEqual(trailingNode.position, trailingPosition - removedNodeCount);
+
+        trailing.value = 2;
+        decoder.decode(encoder.encode());
+        assert.strictEqual(decoder.state.actors.has("departing"), false);
+        assert.strictEqual(decoder.state.trailing.get("sentinel").value, 2);
+    });
+});


### PR DESCRIPTION
## Summary
- start cached-position updates at the removed node successor
- decrement only successor positions instead of rescanning the linked list from its head
- add a deterministic nested-schema regression test covering traversal, cached positions, and encode/decode correctness

## Why
Root.remove recursively removes every ChangeTree in a detached subtree. The previous updatePositionsAfterRemoval implementation walked from the list head for every removed node even though predecessor positions cannot change. With many long-lived schemas before a removed nested actor, removal cost therefore scales with both the preceding list and removed subtree.

Starting at node.next makes the work proportional only to actual successors. Tail removals require no position traversal. This does not change the wire format or removal semantics.

## Benchmark
Node 22.23.1, five runs, 2,000 preceding branches with 24 nested leaves each and one removed branch with 24 leaves:

- master median: 6.205 ms
- this change median: 0.047 ms

The regression test fails on master because predecessor links are revisited and passes with this change.

## Verification
- npm test
- npm run build
- npm run typecheck
- focused Root test